### PR TITLE
provide sophia implementations if the 'sophia' feature is enabled

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -11,6 +11,13 @@ Common data structures for RDF formats parsers and serializers
 """
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = []
 generalized = []
+sophia = ["sophia_api"]
+
+[dependencies]
+sophia_api = { version = "0.6.1", optional = true }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -27,13 +27,8 @@ mod generalized;
 /// It ensures that the types defined in [`model`]
 /// implement the appropriate trait from [Sophia].
 ///
-/// It also provides building blocks to expose Rio parsers
-/// as Sophia parsers.
-///
 /// [Sophia]: https://crates.io/crates/sophia
 /// [`model`]: ../model/index.html
-pub mod sophia {
+mod sophia {
     mod model;
-    mod parser;
-    pub use parser::*;
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -18,3 +18,22 @@ pub mod parser;
 
 #[cfg(feature = "generalized")]
 mod generalized;
+
+#[cfg(feature = "sophia")]
+/// [Sophia] adapters for Rio parsers.
+///
+/// This module is available if feature `sophia` is enabled.
+///
+/// It ensures that the types defined in [`model`]
+/// implement the appropriate trait from [Sophia].
+///
+/// It also provides building blocks to expose Rio parsers
+/// as Sophia parsers.
+///
+/// [Sophia]: https://crates.io/crates/sophia
+/// [`model`]: ../model/index.html
+pub mod sophia {
+    mod model;
+    mod parser;
+    pub use parser::*;
+}

--- a/api/src/sophia/model.rs
+++ b/api/src/sophia/model.rs
@@ -1,6 +1,6 @@
 //! Provide implementation of Sophia traits for Rio types.
 use crate::model::*;
-use sophia_api::ns::xsd;
+use sophia_api::ns::{rdf, xsd};
 #[cfg(feature = "generalized")]
 use sophia_api::quad::Quad as SophiaQuad;
 use sophia_api::term::{RawValue, SimpleIri, TTerm, TermKind};
@@ -61,7 +61,7 @@ impl<'a> TTerm for Literal<'a> {
         match self {
             Literal::Simple { .. } => Some(xsd::string),
             Literal::Typed { datatype, .. } => Some(datatype.into()),
-            _ => None,
+            _ => Some(rdf::langString),
         }
     }
     #[inline]

--- a/api/src/sophia/model.rs
+++ b/api/src/sophia/model.rs
@@ -1,0 +1,212 @@
+//! Provide implementation of Sophia traits for Rio types.
+use crate::model::*;
+use sophia_api::ns::xsd;
+#[cfg(feature = "generalized")]
+use sophia_api::quad::Quad as SophiaQuad;
+use sophia_api::term::{RawValue, SimpleIri, TTerm, TermKind};
+
+impl<'a> TTerm for NamedNode<'a> {
+    #[inline]
+    fn kind(&self) -> TermKind {
+        TermKind::Iri
+    }
+    #[inline]
+    fn value_raw(&self) -> RawValue<'_> {
+        self.iri.into()
+    }
+    #[inline]
+    fn as_dyn(&self) -> &dyn TTerm {
+        self
+    }
+}
+
+impl<'a> From<&NamedNode<'a>> for SimpleIri<'a> {
+    #[inline]
+    fn from(other: &NamedNode<'a>) -> SimpleIri<'a> {
+        SimpleIri::new_unchecked(other.iri, None)
+    }
+}
+
+impl<'a> TTerm for BlankNode<'a> {
+    #[inline]
+    fn kind(&self) -> TermKind {
+        TermKind::BlankNode
+    }
+    #[inline]
+    fn value_raw(&self) -> RawValue<'_> {
+        self.id.into()
+    }
+    #[inline]
+    fn as_dyn(&self) -> &dyn TTerm {
+        self
+    }
+}
+
+impl<'a> TTerm for Literal<'a> {
+    #[inline]
+    fn kind(&self) -> TermKind {
+        TermKind::Literal
+    }
+    #[inline]
+    fn value_raw(&self) -> RawValue<'_> {
+        match self {
+            Literal::Simple { value } => *value,
+            Literal::LanguageTaggedString { value, .. } => *value,
+            Literal::Typed { value, .. } => *value,
+        }
+        .into()
+    }
+    #[inline]
+    fn datatype(&self) -> Option<SimpleIri<'_>> {
+        match self {
+            Literal::Simple { .. } => Some(xsd::string),
+            Literal::Typed { datatype, .. } => Some(datatype.into()),
+            _ => None,
+        }
+    }
+    #[inline]
+    fn language(&self) -> Option<&str> {
+        match self {
+            Literal::LanguageTaggedString { language, .. } => Some(language),
+            _ => None,
+        }
+    }
+    #[inline]
+    fn as_dyn(&self) -> &dyn TTerm {
+        self
+    }
+}
+
+impl<'a> TTerm for NamedOrBlankNode<'a> {
+    #[inline]
+    fn kind(&self) -> TermKind {
+        match self {
+            NamedOrBlankNode::NamedNode(_) => TermKind::Iri,
+            NamedOrBlankNode::BlankNode(_) => TermKind::BlankNode,
+        }
+    }
+    #[inline]
+    fn value_raw(&self) -> RawValue<'_> {
+        match self {
+            NamedOrBlankNode::NamedNode(n) => n.value_raw(),
+            NamedOrBlankNode::BlankNode(n) => n.value_raw(),
+        }
+    }
+    #[inline]
+    fn as_dyn(&self) -> &dyn TTerm {
+        self
+    }
+}
+
+impl<'a> TTerm for Term<'a> {
+    #[inline]
+    fn kind(&self) -> TermKind {
+        match self {
+            Term::NamedNode(_) => TermKind::Iri,
+            Term::BlankNode(_) => TermKind::BlankNode,
+            Term::Literal(_) => TermKind::Literal,
+        }
+    }
+    #[inline]
+    fn value_raw(&self) -> RawValue<'_> {
+        match self {
+            Term::NamedNode(n) => n.value_raw(),
+            Term::BlankNode(n) => n.value_raw(),
+            Term::Literal(l) => l.value_raw(),
+        }
+    }
+    #[inline]
+    fn datatype(&self) -> Option<SimpleIri<'_>> {
+        match self {
+            Term::Literal(l) => l.datatype(),
+            _ => None,
+        }
+    }
+    #[inline]
+    fn language(&self) -> Option<&str> {
+        match self {
+            Term::Literal(l) => l.language(),
+            _ => None,
+        }
+    }
+    #[inline]
+    fn as_dyn(&self) -> &dyn TTerm {
+        self
+    }
+}
+
+#[cfg(feature = "generalized")]
+impl<'a> TTerm for Variable<'a> {
+    #[inline]
+    fn kind(&self) -> TermKind {
+        TermKind::Variable
+    }
+    #[inline]
+    fn value_raw(&self) -> RawValue<'_> {
+        self.name.into()
+    }
+    #[inline]
+    fn as_dyn(&self) -> &dyn TTerm {
+        self
+    }
+}
+
+#[cfg(feature = "generalized")]
+impl<'a> TTerm for GeneralizedTerm<'a> {
+    #[inline]
+    fn kind(&self) -> TermKind {
+        match self {
+            GeneralizedTerm::NamedNode(_) => TermKind::Iri,
+            GeneralizedTerm::BlankNode(_) => TermKind::BlankNode,
+            GeneralizedTerm::Literal(_) => TermKind::Literal,
+            GeneralizedTerm::Variable(_) => TermKind::Variable,
+        }
+    }
+    #[inline]
+    fn value_raw(&self) -> RawValue<'_> {
+        match self {
+            GeneralizedTerm::NamedNode(n) => n.value_raw(),
+            GeneralizedTerm::BlankNode(n) => n.value_raw(),
+            GeneralizedTerm::Literal(l) => l.value_raw(),
+            GeneralizedTerm::Variable(v) => v.value_raw(),
+        }
+    }
+    #[inline]
+    fn datatype(&self) -> Option<SimpleIri<'_>> {
+        match self {
+            GeneralizedTerm::Literal(l) => l.datatype(),
+            _ => None,
+        }
+    }
+    #[inline]
+    fn language(&self) -> Option<&str> {
+        match self {
+            GeneralizedTerm::Literal(l) => l.language(),
+            _ => None,
+        }
+    }
+    #[inline]
+    fn as_dyn(&self) -> &dyn TTerm {
+        self
+    }
+}
+
+// NB: Triple and Quad can not implement sophia's counterparts,
+// because they have different types for s, p and o.
+
+#[cfg(feature = "generalized")]
+impl<'a> SophiaQuad for GeneralizedQuad<'a> {
+    type Term = GeneralizedTerm<'a>;
+    fn s(&self) -> &Self::Term {
+        &self.subject
+    }
+    fn p(&self) -> &Self::Term {
+        &self.predicate
+    }
+    fn o(&self) -> &Self::Term {
+        &self.object
+    }
+    fn g(&self) -> Option<&Self::Term> {
+        self.graph_name.as_ref()
+    }
+}

--- a/api/src/sophia/parser.rs
+++ b/api/src/sophia/parser.rs
@@ -1,0 +1,199 @@
+//! Implementation of sophia TripleSource / QuadSource for rio parsers
+
+use crate::model::*;
+use crate::parser::*;
+use sophia_api::quad::stream::*;
+use sophia_api::quad::streaming_mode::StreamedQuad;
+use sophia_api::triple::stream::*;
+use sophia_api::triple::streaming_mode::StreamedTriple;
+use std::error::Error;
+use std::result::Result as StdResult;
+
+/// TripleSource / QuadSource adapter for TripleParser / QuadParser
+pub enum StrictRioSource<T, E> {
+    Parser(T),
+    Error(Option<E>),
+}
+
+impl<T, E> From<StdResult<T, E>> for StrictRioSource<T, E> {
+    fn from(res: StdResult<T, E>) -> Self {
+        match res {
+            Ok(parser) => StrictRioSource::Parser(parser),
+            Err(error) => StrictRioSource::Error(Some(error)),
+        }
+    }
+}
+
+// This intermediate type is required,
+// because Rio requires that the error type of triple_handler/quad_handler
+// implement From<TurtleError> (or whatever Rio-specific error returned by the parser).
+//
+// This is costless, though,
+// because MyStreamError's internal representation is identical to StreamError,
+// so the final type conversion performed by into_stream_error is actually
+// just for pleasing the compiler.
+enum MyStreamError<E1, E2> {
+    Source(E1),
+    Sink(E2),
+}
+impl<E1, E2> MyStreamError<E1, E2>
+where
+    E1: Error + 'static,
+    E2: Error + 'static,
+{
+    fn from_sink_error(err: E2) -> Self {
+        MyStreamError::Sink(err)
+    }
+    fn into_stream_error(self) -> StreamError<E1, E2> {
+        match self {
+            MyStreamError::Source(err) => SourceError(err),
+            MyStreamError::Sink(err) => SinkError(err),
+        }
+    }
+}
+impl<E1, E2> From<E1> for MyStreamError<E1, E2>
+where
+    E1: Error + 'static,
+    E2: Error + 'static,
+{
+    fn from(other: E1) -> Self {
+        MyStreamError::Source(other)
+    }
+}
+
+pub type RioSourceTriple<'a> = [Term<'a>; 3];
+sophia_api::make_scoped_triple_streaming_mode!(ScopedRioSourceTriple, RioSourceTriple);
+
+impl<T, E> TripleSource for StrictRioSource<T, E>
+where
+    T: TriplesParser<Error = E>,
+    E: Error + 'static,
+{
+    type Error = E;
+    //type Triple = crate::triple::streaming_mode::ByValue<RioSourceTriple<'static>>;
+    type Triple = ScopedRioSourceTriple;
+
+    fn try_for_some_triple<F, EF>(&mut self, f: &mut F) -> StreamResult<bool, E, EF>
+    where
+        F: FnMut(StreamedTriple<'_, Self::Triple>) -> Result<(), EF>,
+        EF: Error,
+    {
+        match self {
+            StrictRioSource::Error(opt) => Err(SourceError(consume_err(opt))),
+            StrictRioSource::Parser(parser) => {
+                if parser.is_end() {
+                    return Ok(false);
+                }
+                parser
+                    .parse_step(&mut |t| -> StdResult<(), MyStreamError<E, EF>> {
+                        f(StreamedTriple::scoped([
+                            t.subject.into(),
+                            t.predicate.into(),
+                            t.object,
+                        ]))
+                        .map_err(MyStreamError::from_sink_error)
+                    })
+                    .map_err(|e| e.into_stream_error())
+                    .and(Ok(true))
+            }
+        }
+    }
+}
+
+pub type RioSourceQuad<'a> = ([Term<'a>; 3], Option<Term<'a>>);
+sophia_api::make_scoped_quad_streaming_mode!(ScopedRioSourceQuad, RioSourceQuad);
+
+impl<T, E> QuadSource for StrictRioSource<T, E>
+where
+    T: QuadsParser<Error = E>,
+    E: Error + 'static,
+{
+    type Error = E;
+    type Quad = ScopedRioSourceQuad;
+
+    fn try_for_some_quad<F, EF>(&mut self, f: &mut F) -> StreamResult<bool, E, EF>
+    where
+        F: FnMut(StreamedQuad<'_, Self::Quad>) -> Result<(), EF>,
+        EF: Error,
+    {
+        match self {
+            StrictRioSource::Error(opt) => Err(SourceError(consume_err(opt))),
+            StrictRioSource::Parser(parser) => {
+                if parser.is_end() {
+                    return Ok(false);
+                }
+                parser
+                    .parse_step(&mut |q| -> StdResult<(), MyStreamError<E, EF>> {
+                        f(StreamedQuad::scoped((
+                            [q.subject.into(), q.predicate.into(), q.object],
+                            q.graph_name.map(|g| g.into()),
+                        )))
+                        .map_err(MyStreamError::from_sink_error)
+                    })
+                    .map_err(|e| e.into_stream_error())
+                    .and(Ok(true))
+            }
+        }
+    }
+}
+
+#[cfg(feature = "generalized")]
+mod generalized {
+    use super::*;
+
+    /// QuadSource adapter for RIO GeneralizedQuadParser
+    pub enum GeneralizedRioSource<T, E> {
+        Parser(T),
+        Error(Option<E>),
+    }
+
+    impl<T, E> From<StdResult<T, E>> for GeneralizedRioSource<T, E> {
+        fn from(res: StdResult<T, E>) -> Self {
+            match res {
+                Ok(parser) => GeneralizedRioSource::Parser(parser),
+                Err(error) => GeneralizedRioSource::Error(Some(error)),
+            }
+        }
+    }
+
+    sophia_api::make_scoped_quad_streaming_mode!(ScopedGeneralizedQuad, GeneralizedQuad);
+
+    impl<T, E> QuadSource for GeneralizedRioSource<T, E>
+    where
+        T: GeneralizedQuadsParser<Error = E>,
+        E: Error + 'static,
+    {
+        type Error = E;
+        type Quad = ScopedGeneralizedQuad;
+
+        fn try_for_some_quad<F, EF>(&mut self, f: &mut F) -> StreamResult<bool, E, EF>
+        where
+            F: FnMut(StreamedQuad<'_, Self::Quad>) -> Result<(), EF>,
+            EF: Error,
+        {
+            match self {
+                GeneralizedRioSource::Error(opt) => Err(SourceError(consume_err(opt))),
+                GeneralizedRioSource::Parser(parser) => {
+                    if parser.is_end() {
+                        return Ok(false);
+                    }
+                    parser
+                        .parse_step(&mut |q| -> StdResult<(), MyStreamError<E, EF>> {
+                            f(StreamedQuad::scoped(q)).map_err(MyStreamError::from_sink_error)
+                        })
+                        .map_err(|e| e.into_stream_error())
+                        .and(Ok(true))
+                }
+            }
+        }
+    }
+}
+#[cfg(feature = "generalized")]
+pub use generalized::*;
+
+/// Consume inner error and convert it to Error
+fn consume_err<E>(opt: &mut Option<E>) -> E {
+    opt.take().unwrap_or_else(|| {
+        panic!("This parser has failed previously, and can not be used anymore");
+    })
+}

--- a/api/src/sophia/parser.rs
+++ b/api/src/sophia/parser.rs
@@ -1,199 +1,182 @@
 //! Implementation of sophia TripleSource / QuadSource for rio parsers
 
-use crate::model::*;
-use crate::parser::*;
 use sophia_api::quad::stream::*;
-use sophia_api::quad::streaming_mode::StreamedQuad;
-use sophia_api::triple::stream::*;
-use sophia_api::triple::streaming_mode::StreamedTriple;
 use std::error::Error;
-use std::result::Result as StdResult;
 
-/// TripleSource / QuadSource adapter for TripleParser / QuadParser
-pub enum StrictRioSource<T, E> {
-    Parser(T),
-    Error(Option<E>),
-}
+#[macro_export]
+/// Implement Sophia's `TripleSource` for a Rio `TriplesParser`.
+macro_rules! impl_triple_source {
+    ($parser:ident) => {
+        mod as_sophia_triple_source {
+            use super::*;
+            use rio_api::model::Term;
+            use rio_api::parser::TriplesParser;
+            use rio_api::sophia::RioStreamError;
+            use sophia_api::triple::stream::*;
+            use sophia_api::triple::streaming_mode::*;
+            use std::error::Error;
+            use std::io::BufRead;
 
-impl<T, E> From<StdResult<T, E>> for StrictRioSource<T, E> {
-    fn from(res: StdResult<T, E>) -> Self {
-        match res {
-            Ok(parser) => StrictRioSource::Parser(parser),
-            Err(error) => StrictRioSource::Error(Some(error)),
-        }
-    }
-}
-
-// This intermediate type is required,
-// because Rio requires that the error type of triple_handler/quad_handler
-// implement From<TurtleError> (or whatever Rio-specific error returned by the parser).
-//
-// This is costless, though,
-// because MyStreamError's internal representation is identical to StreamError,
-// so the final type conversion performed by into_stream_error is actually
-// just for pleasing the compiler.
-enum MyStreamError<E1, E2> {
-    Source(E1),
-    Sink(E2),
-}
-impl<E1, E2> MyStreamError<E1, E2>
-where
-    E1: Error + 'static,
-    E2: Error + 'static,
-{
-    fn from_sink_error(err: E2) -> Self {
-        MyStreamError::Sink(err)
-    }
-    fn into_stream_error(self) -> StreamError<E1, E2> {
-        match self {
-            MyStreamError::Source(err) => SourceError(err),
-            MyStreamError::Sink(err) => SinkError(err),
-        }
-    }
-}
-impl<E1, E2> From<E1> for MyStreamError<E1, E2>
-where
-    E1: Error + 'static,
-    E2: Error + 'static,
-{
-    fn from(other: E1) -> Self {
-        MyStreamError::Source(other)
-    }
-}
-
-pub type RioSourceTriple<'a> = [Term<'a>; 3];
-sophia_api::make_scoped_triple_streaming_mode!(ScopedRioSourceTriple, RioSourceTriple);
-
-impl<T, E> TripleSource for StrictRioSource<T, E>
-where
-    T: TriplesParser<Error = E>,
-    E: Error + 'static,
-{
-    type Error = E;
-    //type Triple = crate::triple::streaming_mode::ByValue<RioSourceTriple<'static>>;
-    type Triple = ScopedRioSourceTriple;
-
-    fn try_for_some_triple<F, EF>(&mut self, f: &mut F) -> StreamResult<bool, E, EF>
-    where
-        F: FnMut(StreamedTriple<'_, Self::Triple>) -> Result<(), EF>,
-        EF: Error,
-    {
-        match self {
-            StrictRioSource::Error(opt) => Err(SourceError(consume_err(opt))),
-            StrictRioSource::Parser(parser) => {
-                if parser.is_end() {
-                    return Ok(false);
-                }
-                parser
-                    .parse_step(&mut |t| -> StdResult<(), MyStreamError<E, EF>> {
+            impl<B: BufRead> TripleSource for $parser<B> {
+                type Error = <$parser<B> as TriplesParser>::Error;
+                type Triple = ScopedRioSourceTriple;
+                fn try_for_some_triple<F, EF>(
+                    &mut self,
+                    f: &mut F,
+                ) -> StreamResult<bool, Self::Error, EF>
+                where
+                    F: FnMut(StreamedTriple<'_, Self::Triple>) -> Result<(), EF>,
+                    EF: Error,
+                {
+                    if self.is_end() {
+                        return Ok(false);
+                    }
+                    self.parse_step(&mut |t| -> Result<(), RioStreamError<Self::Error, EF>> {
                         f(StreamedTriple::scoped([
                             t.subject.into(),
                             t.predicate.into(),
                             t.object,
                         ]))
-                        .map_err(MyStreamError::from_sink_error)
+                        .map_err(|e| SinkError(e).into())
                     })
-                    .map_err(|e| e.into_stream_error())
+                    .map_err(|e| e.into())
                     .and(Ok(true))
+                }
             }
+
+            /// Convenient type alias.
+            type RioSourceTriple<'a> = [Term<'a>; 3];
+            sophia_api::make_scoped_triple_streaming_mode!(ScopedRioSourceTriple, RioSourceTriple);
         }
-    }
+    };
 }
 
-pub type RioSourceQuad<'a> = ([Term<'a>; 3], Option<Term<'a>>);
-sophia_api::make_scoped_quad_streaming_mode!(ScopedRioSourceQuad, RioSourceQuad);
+#[macro_export]
+/// Implement Sophia's `QuadSource` for a Rio `QuadsParser`.
+macro_rules! impl_quad_source {
+    ($parser:ident) => {
+        mod as_sophia_quad_source {
+            use super::*;
+            use rio_api::model::Term;
+            use rio_api::parser::QuadsParser;
+            use rio_api::sophia::RioStreamError;
+            use sophia_api::quad::stream::*;
+            use sophia_api::quad::streaming_mode::*;
+            use std::error::Error;
+            use std::io::BufRead;
 
-impl<T, E> QuadSource for StrictRioSource<T, E>
-where
-    T: QuadsParser<Error = E>,
-    E: Error + 'static,
-{
-    type Error = E;
-    type Quad = ScopedRioSourceQuad;
-
-    fn try_for_some_quad<F, EF>(&mut self, f: &mut F) -> StreamResult<bool, E, EF>
-    where
-        F: FnMut(StreamedQuad<'_, Self::Quad>) -> Result<(), EF>,
-        EF: Error,
-    {
-        match self {
-            StrictRioSource::Error(opt) => Err(SourceError(consume_err(opt))),
-            StrictRioSource::Parser(parser) => {
-                if parser.is_end() {
-                    return Ok(false);
-                }
-                parser
-                    .parse_step(&mut |q| -> StdResult<(), MyStreamError<E, EF>> {
+            impl<B: BufRead> QuadSource for $parser<B> {
+                type Error = <$parser<B> as QuadsParser>::Error;
+                type Quad = ScopedRioSourceQuad;
+                fn try_for_some_quad<F, EF>(
+                    &mut self,
+                    f: &mut F,
+                ) -> StreamResult<bool, Self::Error, EF>
+                where
+                    F: FnMut(StreamedQuad<'_, Self::Quad>) -> Result<(), EF>,
+                    EF: Error,
+                {
+                    if self.is_end() {
+                        return Ok(false);
+                    }
+                    self.parse_step(&mut |q| -> Result<(), RioStreamError<Self::Error, EF>> {
                         f(StreamedQuad::scoped((
                             [q.subject.into(), q.predicate.into(), q.object],
                             q.graph_name.map(|g| g.into()),
                         )))
-                        .map_err(MyStreamError::from_sink_error)
+                        .map_err(|e| SinkError(e).into())
                     })
-                    .map_err(|e| e.into_stream_error())
+                    .map_err(|e| e.into())
                     .and(Ok(true))
-            }
-        }
-    }
-}
-
-#[cfg(feature = "generalized")]
-mod generalized {
-    use super::*;
-
-    /// QuadSource adapter for RIO GeneralizedQuadParser
-    pub enum GeneralizedRioSource<T, E> {
-        Parser(T),
-        Error(Option<E>),
-    }
-
-    impl<T, E> From<StdResult<T, E>> for GeneralizedRioSource<T, E> {
-        fn from(res: StdResult<T, E>) -> Self {
-            match res {
-                Ok(parser) => GeneralizedRioSource::Parser(parser),
-                Err(error) => GeneralizedRioSource::Error(Some(error)),
-            }
-        }
-    }
-
-    sophia_api::make_scoped_quad_streaming_mode!(ScopedGeneralizedQuad, GeneralizedQuad);
-
-    impl<T, E> QuadSource for GeneralizedRioSource<T, E>
-    where
-        T: GeneralizedQuadsParser<Error = E>,
-        E: Error + 'static,
-    {
-        type Error = E;
-        type Quad = ScopedGeneralizedQuad;
-
-        fn try_for_some_quad<F, EF>(&mut self, f: &mut F) -> StreamResult<bool, E, EF>
-        where
-            F: FnMut(StreamedQuad<'_, Self::Quad>) -> Result<(), EF>,
-            EF: Error,
-        {
-            match self {
-                GeneralizedRioSource::Error(opt) => Err(SourceError(consume_err(opt))),
-                GeneralizedRioSource::Parser(parser) => {
-                    if parser.is_end() {
-                        return Ok(false);
-                    }
-                    parser
-                        .parse_step(&mut |q| -> StdResult<(), MyStreamError<E, EF>> {
-                            f(StreamedQuad::scoped(q)).map_err(MyStreamError::from_sink_error)
-                        })
-                        .map_err(|e| e.into_stream_error())
-                        .and(Ok(true))
                 }
             }
+
+            /// Convenient type alias.
+            type RioSourceQuad<'a> = ([Term<'a>; 3], Option<Term<'a>>);
+            sophia_api::make_scoped_quad_streaming_mode!(ScopedRioSourceQuad, RioSourceQuad);
         }
+    };
+}
+
+#[cfg(feature = "generalized")]
+#[macro_export]
+/// Implement Sophia's `QuadSource` for a Rio `GeneralizedQuadsParser`.
+macro_rules! impl_quad_source_generalized {
+    ($parser:ident) => {
+        mod as_sophia_quad_source {
+            use super::*;
+            use rio_api::model::{GeneralizedQuad, Term};
+            use rio_api::parser::GeneralizedQuadsParser;
+            use rio_api::sophia::RioStreamError;
+            use sophia_api::quad::stream::*;
+            use sophia_api::quad::streaming_mode::*;
+            use std::error::Error;
+            use std::io::BufRead;
+
+            impl<B: BufRead> QuadSource for $parser<B> {
+                type Error = <$parser<B> as GeneralizedQuadsParser>::Error;
+                type Quad = ScopedGeneralizedQuad;
+                fn try_for_some_quad<F, EF>(
+                    &mut self,
+                    f: &mut F,
+                ) -> StreamResult<bool, Self::Error, EF>
+                where
+                    F: FnMut(StreamedQuad<'_, Self::Quad>) -> Result<(), EF>,
+                    EF: Error,
+                {
+                    if self.is_end() {
+                        return Ok(false);
+                    }
+                    self.parse_step(&mut |q| -> Result<(), RioStreamError<Self::Error, EF>> {
+                        f(StreamedQuad::scoped(q)).map_err(|e| SinkError(e).into())
+                    })
+                    .map_err(|e| e.into())
+                    .and(Ok(true))
+                }
+            }
+
+            sophia_api::make_scoped_quad_streaming_mode!(ScopedGeneralizedQuad, GeneralizedQuad);
+        }
+    };
+}
+
+// A wrapper around Sophia's `StreamError`
+// fullfilling Rio's expectation that the error type of `triple_handler`/`quad_handler`
+// implement From<TurtleError> (or whatever Rio-specific error returned by the parser).
+pub struct RioStreamError<E1, E2>(StreamError<E1, E2>)
+where
+    E1: Error + 'static,
+    E2: Error + 'static;
+
+impl<E1, E2> From<E1> for RioStreamError<E1, E2>
+where
+    E1: Error + 'static,
+    E2: Error + 'static,
+{
+    #[inline]
+    fn from(other: E1) -> Self {
+        RioStreamError(SourceError(other))
     }
 }
-#[cfg(feature = "generalized")]
-pub use generalized::*;
 
-/// Consume inner error and convert it to Error
-fn consume_err<E>(opt: &mut Option<E>) -> E {
-    opt.take().unwrap_or_else(|| {
-        panic!("This parser has failed previously, and can not be used anymore");
-    })
+impl<E1, E2> From<StreamError<E1, E2>> for RioStreamError<E1, E2>
+where
+    E1: Error + 'static,
+    E2: Error + 'static,
+{
+    #[inline]
+    fn from(other: StreamError<E1, E2>) -> Self {
+        RioStreamError(other)
+    }
+}
+
+impl<E1, E2> From<RioStreamError<E1, E2>> for StreamError<E1, E2>
+where
+    E1: Error + 'static,
+    E2: Error + 'static,
+{
+    #[inline]
+    fn from(other: RioStreamError<E1, E2>) -> Self {
+        other.0
+    }
 }

--- a/turtle/Cargo.toml
+++ b/turtle/Cargo.toml
@@ -11,11 +11,20 @@ RDF Turtle, Trig, N-Triples and N-Quads parsers and serializers
 """
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 oxilangtag = "0.1"
 oxiri = "0.1"
 rio_api = "0.4"
+sophia_api = { version = "0.6.1", optional = true }
+
+[dev-dependencies.sophia_api]
+version = "0.6.1"
+features = ["test_macro"]
 
 [features]
 default = []
 generalized = ["rio_api/generalized"]
+sophia = ["rio_api/sophia", "sophia_api"]

--- a/turtle/src/lib.rs
+++ b/turtle/src/lib.rs
@@ -59,3 +59,25 @@ pub use turtle::TurtleParser;
 
 #[cfg(feature = "generalized")]
 pub use gtrig::GTriGParser;
+
+/// [Sophia] adapters for Rio parsers.
+///
+/// This module is available if feature `sophia` is enabled.
+///
+/// [Sophia]: https://crates.io/crates/sophia
+#[cfg(feature = "sophia")]
+pub mod sophia {
+    #[cfg(feature = "generalized")]
+    mod gtrig;
+    mod nq;
+    mod nt;
+    mod trig;
+    mod turtle;
+
+    #[cfg(feature = "generalized")]
+    pub use gtrig::*;
+    pub use nq::*;
+    pub use nt::*;
+    pub use trig::*;
+    pub use turtle::*;
+}

--- a/turtle/src/lib.rs
+++ b/turtle/src/lib.rs
@@ -66,18 +66,11 @@ pub use gtrig::GTriGParser;
 ///
 /// [Sophia]: https://crates.io/crates/sophia
 #[cfg(feature = "sophia")]
-pub mod sophia {
+mod sophia {
     #[cfg(feature = "generalized")]
     mod gtrig;
     mod nq;
     mod nt;
     mod trig;
     mod turtle;
-
-    #[cfg(feature = "generalized")]
-    pub use gtrig::*;
-    pub use nq::*;
-    pub use nt::*;
-    pub use trig::*;
-    pub use turtle::*;
 }

--- a/turtle/src/lib.rs
+++ b/turtle/src/lib.rs
@@ -66,11 +66,4 @@ pub use gtrig::GTriGParser;
 ///
 /// [Sophia]: https://crates.io/crates/sophia
 #[cfg(feature = "sophia")]
-mod sophia {
-    #[cfg(feature = "generalized")]
-    mod gtrig;
-    mod nq;
-    mod nt;
-    mod trig;
-    mod turtle;
-}
+mod sophia;

--- a/turtle/src/sophia/gtrig.rs
+++ b/turtle/src/sophia/gtrig.rs
@@ -1,0 +1,141 @@
+//! [Sophia] adapter for [generalized] [TriG]
+//!
+//! Using it requires to enable the `generalized` feature.
+//!
+//! Example: count the number of of people using the `Sophia` API:
+//! ```
+//! use rio_api::model::NamedNode;
+//! use rio_turtle::sophia::GTriGParser;
+//! use sophia_api::parser::QuadParser;
+//! use sophia_api::quad::{Quad, stream::QuadSource};
+//! use sophia_api::term::term_eq;
+//! use sophia_api::ns::rdf;
+//!
+//! let file = b"@prefix schema: <http://schema.org/> .
+//! <http://example/> {
+//!     <http://example.com/foo> a schema:Person ;
+//!         schema:name  ?name .
+//!     <http://example.com/bar> a schema:Person ;
+//!         schema:name  ?name .
+//! }";
+//!
+//! let schema_person = NamedNode { iri: "http://schema.org/Person" };
+//! let mut count = 0;
+//! GTriGParser::default()
+//!     .parse(file.as_ref())
+//!     .filter_quads(|q| term_eq(q.p(), &rdf::type_) && term_eq(q.o(), &schema_person))
+//!     .for_each_quad(|_| { count += 1; })
+//!     .unwrap();
+//! assert_eq!(2, count)
+//! ```
+//!
+//! [Sophia]: https://crates.io/crates/sophia
+//! [generalized]: https://docs.rs/sophia/latest/sophia/#generalized-vs-strict-rdf-model
+//! [TriG]: https://www.w3.org/TR/trig/
+
+use crate::{GTriGParser as RioGTriGParser, TurtleError};
+use rio_api::sophia::GeneralizedRioSource;
+use sophia_api::parser::QuadParser;
+use std::io::BufRead;
+
+/// An implementation of [`sophia_api::parser::QuadParser`]
+/// around [the generalized trig parser].
+///
+/// [`sophia_api::parser::QuadParser`]: https://docs.rs/sophia_api/latest/sophia_api/parser/trait.QuadParser.html
+/// [the generalized trig parser]: ../../struct.GTriGParser.html
+#[derive(Clone, Debug, Default)]
+pub struct GTriGParser {
+    pub base: Option<String>,
+}
+
+impl<B: BufRead> QuadParser<B> for GTriGParser {
+    type Source = GeneralizedRioSource<RioGTriGParser<B>, TurtleError>;
+    fn parse(&self, data: B) -> Self::Source {
+        let base: &str = match &self.base {
+            Some(base) => &base,
+            None => "",
+        };
+        GeneralizedRioSource::from(RioGTriGParser::new(data, base))
+    }
+}
+
+sophia_api::def_mod_functions_for_bufread_parser!(GTriGParser, QuadParser);
+
+// ---------------------------------------------------------------------------------
+//                                      tests
+// ---------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rio_api::model::{NamedNode, Variable};
+    use sophia_api::dataset::Dataset;
+    use sophia_api::ns::rdf;
+    use sophia_api::quad::stream::QuadSource;
+    use sophia_api::term::matcher::ANY;
+    use sophia_api::term::test::TestTerm;
+
+    #[test]
+    fn test_simple_gtrig_string() -> Result<(), Box<dyn std::error::Error>> {
+        let gtrig = r#"
+            @prefix : <http://example.org/ns/> .
+
+            <#g1> {
+                <#me> :knows _:alice.
+            }
+            <#g2> {
+                _:alice a :Person ; :name ?name.
+            }
+        "#;
+
+        let p = GTriGParser {
+            base: Some("http://localhost/ex".into()),
+        };
+
+        let d: Vec<([TestTerm<String>; 3], Option<TestTerm<String>>)> =
+            p.parse_str(&gtrig).collect_quads()?;
+        assert_eq!(d.len(), 3);
+        assert!(d
+            .quads_matching(
+                &NamedNode {
+                    iri: "http://localhost/ex#me"
+                },
+                &NamedNode {
+                    iri: "http://example.org/ns/knows"
+                },
+                &ANY,
+                &Some(&NamedNode {
+                    iri: "http://localhost/ex#g1"
+                }),
+            )
+            .next()
+            .is_some());
+        assert!(d
+            .quads_matching(
+                &ANY,
+                &rdf::type_,
+                &NamedNode {
+                    iri: "http://example.org/ns/Person"
+                },
+                &Some(&NamedNode {
+                    iri: "http://localhost/ex#g2"
+                }),
+            )
+            .next()
+            .is_some());
+        assert!(d
+            .quads_matching(
+                &ANY,
+                &NamedNode {
+                    iri: "http://example.org/ns/name"
+                },
+                &Variable { name: "name" },
+                &Some(&NamedNode {
+                    iri: "http://localhost/ex#g2"
+                }),
+            )
+            .next()
+            .is_some());
+        Ok(())
+    }
+}

--- a/turtle/src/sophia/gtrig.rs
+++ b/turtle/src/sophia/gtrig.rs
@@ -35,7 +35,7 @@
 
 use crate::GTriGParser;
 
-rio_api::impl_quad_source_generalized!(GTriGParser);
+impl_quad_source_generalized!(GTriGParser);
 
 // ---------------------------------------------------------------------------------
 //                                      tests

--- a/turtle/src/sophia/mod.rs
+++ b/turtle/src/sophia/mod.rs
@@ -1,17 +1,16 @@
-//! Implementation of sophia TripleSource / QuadSource for rio parsers
+//! Utility macros and types for exposing Sophia's TripleSource / QuadSource.
 
 use sophia_api::quad::stream::*;
 use std::error::Error;
 
-#[macro_export]
 /// Implement Sophia's `TripleSource` for a Rio `TriplesParser`.
 macro_rules! impl_triple_source {
     ($parser:ident) => {
         mod as_sophia_triple_source {
             use super::*;
+            use crate::sophia::RioStreamError;
             use rio_api::model::Term;
             use rio_api::parser::TriplesParser;
-            use rio_api::sophia::RioStreamError;
             use sophia_api::triple::stream::*;
             use sophia_api::triple::streaming_mode::*;
             use std::error::Error;
@@ -51,15 +50,14 @@ macro_rules! impl_triple_source {
     };
 }
 
-#[macro_export]
 /// Implement Sophia's `QuadSource` for a Rio `QuadsParser`.
 macro_rules! impl_quad_source {
     ($parser:ident) => {
         mod as_sophia_quad_source {
             use super::*;
+            use crate::sophia::RioStreamError;
             use rio_api::model::Term;
             use rio_api::parser::QuadsParser;
-            use rio_api::sophia::RioStreamError;
             use sophia_api::quad::stream::*;
             use sophia_api::quad::streaming_mode::*;
             use std::error::Error;
@@ -99,15 +97,14 @@ macro_rules! impl_quad_source {
 }
 
 #[cfg(feature = "generalized")]
-#[macro_export]
 /// Implement Sophia's `QuadSource` for a Rio `GeneralizedQuadsParser`.
 macro_rules! impl_quad_source_generalized {
     ($parser:ident) => {
         mod as_sophia_quad_source {
             use super::*;
-            use rio_api::model::{GeneralizedQuad, Term};
+            use crate::sophia::RioStreamError;
+            use rio_api::model::GeneralizedQuad;
             use rio_api::parser::GeneralizedQuadsParser;
-            use rio_api::sophia::RioStreamError;
             use sophia_api::quad::stream::*;
             use sophia_api::quad::streaming_mode::*;
             use std::error::Error;
@@ -143,7 +140,7 @@ macro_rules! impl_quad_source_generalized {
 // A wrapper around Sophia's `StreamError`
 // fullfilling Rio's expectation that the error type of `triple_handler`/`quad_handler`
 // implement From<TurtleError> (or whatever Rio-specific error returned by the parser).
-pub struct RioStreamError<E1, E2>(StreamError<E1, E2>)
+struct RioStreamError<E1, E2>(StreamError<E1, E2>)
 where
     E1: Error + 'static,
     E2: Error + 'static;
@@ -180,3 +177,10 @@ where
         other.0
     }
 }
+
+#[cfg(feature = "generalized")]
+mod gtrig;
+mod nq;
+mod nt;
+mod trig;
+mod turtle;

--- a/turtle/src/sophia/nq.rs
+++ b/turtle/src/sophia/nq.rs
@@ -1,0 +1,120 @@
+//! [Sophia] adapter for [N-Quads].
+//!
+//!
+//! Example: count the number of of people using the `Sophia` API:
+//! ```
+//! use rio_api::model::NamedNode;
+//! use rio_turtle::sophia::NQuadsParser;
+//! use sophia_api::parser::QuadParser;
+//! use sophia_api::quad::{Quad, stream::QuadSource};
+//! use sophia_api::term::term_eq;
+//! use sophia_api::ns::rdf;
+//!
+//! let file = b"
+//! <http://example.com/foo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> <http://example/>.
+//! <http://example.com/foo> <http://schema.org/name>  \"Foo\" <http://example/>.
+//! <http://example.com/bar> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person>  <http://example/>.
+//! <http://example.com/bar> <http://schema.org/name>  \"Bar\" <http://example/>.
+//! ";
+//!
+//! let schema_person = NamedNode { iri: "http://schema.org/Person" };
+//! let mut count = 0;
+//! NQuadsParser::default()
+//!     .parse(file.as_ref())
+//!     .filter_quads(|q| term_eq(q.p(), &rdf::type_) && term_eq(q.o(), &schema_person))
+//!     .for_each_quad(|_| { count += 1; })
+//!     .unwrap();
+//! assert_eq!(2, count)
+//! ```
+//!
+//! [Sophia]: https://crates.io/crates/sophia
+//! [N-Quads]: https://www.w3.org/TR/n-quads/
+
+use crate::{NQuadsParser as RioNQParser, TurtleError};
+use rio_api::sophia::StrictRioSource;
+use sophia_api::parser::QuadParser;
+use std::io::BufRead;
+
+/// An implementation of [`sophia_api::parser::QuadParser`]
+/// around [the n-quads parser].
+///
+/// [`sophia_api::parser::QuadParser`]: https://docs.rs/sophia_api/latest/sophia_api/parser/trait.QuadParser.html
+/// [the n-quads parser]: ../../struct.NQuadsParser.html
+#[derive(Copy, Clone, Debug, Default)]
+pub struct NQuadsParser {}
+
+impl<B: BufRead> QuadParser<B> for NQuadsParser {
+    type Source = StrictRioSource<RioNQParser<B>, TurtleError>;
+    fn parse(&self, data: B) -> Self::Source {
+        StrictRioSource::from(RioNQParser::new(data))
+    }
+}
+
+sophia_api::def_mod_functions_for_bufread_parser!(NQuadsParser, QuadParser);
+
+// ---------------------------------------------------------------------------------
+//                                      tests
+// ---------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rio_api::model::{Literal, NamedNode};
+    use sophia_api::dataset::Dataset;
+    use sophia_api::ns::rdf;
+    use sophia_api::quad::stream::QuadSource;
+    use sophia_api::term::matcher::ANY;
+    use sophia_api::term::test::TestTerm;
+
+    #[test]
+    fn test_simple_nq_string() -> Result<(), Box<dyn std::error::Error>> {
+        let nquads = r#"
+            <http://localhost/ex#me> <http://example.org/ns/knows> _:b1.
+            _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns/Person> <tag:g1>.
+            _:b1 <http://example.org/ns/name> "Alice" <tag:g1>.
+        "#;
+
+        let p = NQuadsParser {};
+
+        let d: Vec<([TestTerm<String>; 3], Option<TestTerm<String>>)> =
+            p.parse_str(&nquads).collect_quads()?;
+        assert_eq!(d.len(), 3);
+        assert!(d
+            .quads_matching(
+                &NamedNode {
+                    iri: "http://localhost/ex#me"
+                },
+                &NamedNode {
+                    iri: "http://example.org/ns/knows"
+                },
+                &ANY,
+                #[allow(trivial_casts)]
+                &(None as Option<&NamedNode<'_>>),
+            )
+            .next()
+            .is_some());
+        assert!(d
+            .quads_matching(
+                &ANY,
+                &rdf::type_,
+                &NamedNode {
+                    iri: "http://example.org/ns/Person"
+                },
+                &Some(&NamedNode { iri: "tag:g1" }),
+            )
+            .next()
+            .is_some());
+        assert!(d
+            .quads_matching(
+                &ANY,
+                &NamedNode {
+                    iri: "http://example.org/ns/name"
+                },
+                &Literal::Simple { value: "Alice" },
+                &Some(&NamedNode { iri: "tag:g1" }),
+            )
+            .next()
+            .is_some());
+        Ok(())
+    }
+}

--- a/turtle/src/sophia/nq.rs
+++ b/turtle/src/sophia/nq.rs
@@ -32,7 +32,7 @@
 
 use crate::NQuadsParser;
 
-rio_api::impl_quad_source!(NQuadsParser);
+impl_quad_source!(NQuadsParser);
 
 // ---------------------------------------------------------------------------------
 //                                      tests

--- a/turtle/src/sophia/nt.rs
+++ b/turtle/src/sophia/nt.rs
@@ -30,7 +30,7 @@
 
 use crate::NTriplesParser;
 
-rio_api::impl_triple_source!(NTriplesParser);
+impl_triple_source!(NTriplesParser);
 
 // ---------------------------------------------------------------------------------
 //                                      tests

--- a/turtle/src/sophia/nt.rs
+++ b/turtle/src/sophia/nt.rs
@@ -1,0 +1,114 @@
+//! [Sophia] adapter for [N-Triples].
+//!
+//! Example: count the number of of people using the `Sophia` API:
+//! ```
+//! use rio_api::model::NamedNode;
+//! use rio_turtle::sophia::TurtleParser;
+//! use sophia_api::parser::TripleParser;
+//! use sophia_api::triple::{Triple, stream::TripleSource};
+//! use sophia_api::term::term_eq;
+//! use sophia_api::ns::rdf;
+//!
+//! let file = b"
+//! <http://example.com/foo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person>.
+//! <http://example.com/foo> <http://schema.org/name>  \"Foo\".
+//! <http://example.com/bar> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .
+//! <http://example.com/bar> <http://schema.org/name>  \"Bar\".
+//! ";
+//!
+//! let schema_person = NamedNode { iri: "http://schema.org/Person" };
+//! let mut count = 0;
+//! TurtleParser::default()
+//!     .parse(file.as_ref())
+//!     .filter_triples(|t| term_eq(t.p(), &rdf::type_) && term_eq(t.o(), &schema_person))
+//!     .for_each_triple(|_| { count += 1; })
+//!     .unwrap();
+//! assert_eq!(2, count)
+//! ```
+//!
+//! [Sophia]: https://crates.io/crates/sophia
+//! [N-Triples]: https://www.w3.org/TR/n-triples/
+
+use crate::{NTriplesParser as RioNTParser, TurtleError};
+use rio_api::sophia::StrictRioSource;
+use sophia_api::parser::TripleParser;
+use std::io::BufRead;
+
+/// An implementation of [`sophia_api::parser::TripleParser`]
+/// around [the n-triples parser].
+///
+/// [`sophia_api::parser::TripleParser`]: https://docs.rs/sophia_api/latest/sophia_api/parser/trait.TripleParser.html
+/// [the n-triples parser]: ../../struct.NTriplesParser.html
+#[derive(Copy, Clone, Debug, Default)]
+pub struct NTriplesParser {}
+
+impl<B: BufRead> TripleParser<B> for NTriplesParser {
+    type Source = StrictRioSource<RioNTParser<B>, TurtleError>;
+    fn parse(&self, data: B) -> Self::Source {
+        StrictRioSource::from(RioNTParser::new(data))
+    }
+}
+
+sophia_api::def_mod_functions_for_bufread_parser!(NTriplesParser, TripleParser);
+
+// ---------------------------------------------------------------------------------
+//                                      tests
+// ---------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rio_api::model::{Literal, NamedNode};
+    use sophia_api::graph::Graph;
+    use sophia_api::ns::rdf;
+    use sophia_api::term::matcher::ANY;
+    use sophia_api::term::test::TestTerm;
+    use sophia_api::triple::stream::TripleSource;
+
+    #[test]
+    fn test_simple_nt_string() -> Result<(), Box<dyn std::error::Error>> {
+        let ntriples = r#"
+            <http://localhost/ex#me> <http://example.org/ns/knows> _:b1.
+            _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns/Person>.
+            _:b1 <http://example.org/ns/name> "Alice".
+        "#;
+
+        let p = NTriplesParser {};
+
+        let g: Vec<[TestTerm<String>; 3]> = p.parse_str(&ntriples).collect_triples()?;
+        assert_eq!(g.len(), 3);
+        assert!(g
+            .triples_matching(
+                &NamedNode {
+                    iri: "http://localhost/ex#me"
+                },
+                &NamedNode {
+                    iri: "http://example.org/ns/knows"
+                },
+                &ANY,
+            )
+            .next()
+            .is_some());
+        assert!(g
+            .triples_matching(
+                &ANY,
+                &rdf::type_,
+                &NamedNode {
+                    iri: "http://example.org/ns/Person"
+                },
+            )
+            .next()
+            .is_some());
+        assert!(g
+            .triples_matching(
+                &ANY,
+                &NamedNode {
+                    iri: "http://example.org/ns/name"
+                },
+                &Literal::Simple { value: "Alice" },
+            )
+            .next()
+            .is_some());
+        Ok(())
+    }
+}

--- a/turtle/src/sophia/trig.rs
+++ b/turtle/src/sophia/trig.rs
@@ -1,0 +1,138 @@
+//! [Sophia] adapter for [TriG]
+//!
+//! Example: count the number of of people using the `Sophia` API:
+//! ```
+//! use rio_api::model::NamedNode;
+//! use rio_turtle::sophia::TriGParser;
+//! use sophia_api::parser::QuadParser;
+//! use sophia_api::quad::{Quad, stream::QuadSource};
+//! use sophia_api::term::term_eq;
+//! use sophia_api::ns::rdf;
+//!
+//! let file = b"@prefix schema: <http://schema.org/> .
+//! <http://example/> {
+//!     <http://example.com/foo> a schema:Person ;
+//!         schema:name  \"Foo\" .
+//!     <http://example.com/bar> a schema:Person ;
+//!         schema:name  \"Bar\" .
+//! }";
+//!
+//! let schema_person = NamedNode { iri: "http://schema.org/Person" };
+//! let mut count = 0;
+//! TriGParser::default()
+//!     .parse(file.as_ref())
+//!     .filter_quads(|q| term_eq(q.p(), &rdf::type_) && term_eq(q.o(), &schema_person))
+//!     .for_each_quad(|_| { count += 1; })
+//!     .unwrap();
+//! assert_eq!(2, count)
+//! ```
+//!
+//! [Sophia]: https://crates.io/crates/sophia
+//! [TriG]: https://www.w3.org/TR/trig/
+
+use crate::{TriGParser as RioTriGParser, TurtleError};
+use rio_api::sophia::StrictRioSource;
+use sophia_api::parser::QuadParser;
+use std::io::BufRead;
+
+/// An implementation of [`sophia_api::parser::QuadParser`]
+/// around [the trig parser].
+///
+/// [`sophia_api::parser::QuadParser`]: https://docs.rs/sophia_api/latest/sophia_api/parser/trait.QuadParser.html
+/// [the trig parser]: ../../struct.TriGParser.html
+#[derive(Clone, Debug, Default)]
+pub struct TriGParser {
+    pub base: Option<String>,
+}
+
+impl<B: BufRead> QuadParser<B> for TriGParser {
+    type Source = StrictRioSource<RioTriGParser<B>, TurtleError>;
+    fn parse(&self, data: B) -> Self::Source {
+        let base: &str = match &self.base {
+            Some(base) => &base,
+            None => "x-no-base:///",
+        };
+        StrictRioSource::from(RioTriGParser::new(data, base))
+    }
+}
+
+sophia_api::def_mod_functions_for_bufread_parser!(TriGParser, QuadParser);
+
+// ---------------------------------------------------------------------------------
+//                                      tests
+// ---------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rio_api::model::{Literal, NamedNode};
+    use sophia_api::dataset::Dataset;
+    use sophia_api::ns::rdf;
+    use sophia_api::quad::stream::QuadSource;
+    use sophia_api::term::matcher::ANY;
+    use sophia_api::term::test::TestTerm;
+
+    #[test]
+    fn test_simple_trig_string() -> Result<(), Box<dyn std::error::Error>> {
+        let trig = r#"
+            @prefix : <http://example.org/ns/> .
+
+            <#g1> {
+                <#me> :knows _:alice.
+            }
+            <#g2> {
+                _:alice a :Person ; :name "Alice".
+            }
+        "#;
+
+        let p = TriGParser {
+            base: Some("http://localhost/ex".into()),
+        };
+
+        let d: Vec<([TestTerm<String>; 3], Option<TestTerm<String>>)> =
+            p.parse_str(&trig).collect_quads()?;
+        assert_eq!(d.len(), 3);
+        assert!(d
+            .quads_matching(
+                &NamedNode {
+                    iri: "http://localhost/ex#me"
+                },
+                &NamedNode {
+                    iri: "http://example.org/ns/knows"
+                },
+                &ANY,
+                &Some(&NamedNode {
+                    iri: "http://localhost/ex#g1"
+                }),
+            )
+            .next()
+            .is_some());
+        assert!(d
+            .quads_matching(
+                &ANY,
+                &rdf::type_,
+                &NamedNode {
+                    iri: "http://example.org/ns/Person"
+                },
+                &Some(&NamedNode {
+                    iri: "http://localhost/ex#g2"
+                }),
+            )
+            .next()
+            .is_some());
+        assert!(d
+            .quads_matching(
+                &ANY,
+                &NamedNode {
+                    iri: "http://example.org/ns/name"
+                },
+                &Literal::Simple { value: "Alice" },
+                &Some(&NamedNode {
+                    iri: "http://localhost/ex#g2"
+                }),
+            )
+            .next()
+            .is_some());
+        Ok(())
+    }
+}

--- a/turtle/src/sophia/trig.rs
+++ b/turtle/src/sophia/trig.rs
@@ -32,7 +32,7 @@
 
 use crate::TriGParser;
 
-rio_api::impl_quad_source!(TriGParser);
+impl_quad_source!(TriGParser);
 
 // ---------------------------------------------------------------------------------
 //                                      tests

--- a/turtle/src/sophia/turtle.rs
+++ b/turtle/src/sophia/turtle.rs
@@ -41,7 +41,7 @@ impl WithLocation for TurtleError {
     }
 }
 
-rio_api::impl_triple_source!(TurtleParser);
+impl_triple_source!(TurtleParser);
 
 // ---------------------------------------------------------------------------------
 //                                      tests

--- a/turtle/src/sophia/turtle.rs
+++ b/turtle/src/sophia/turtle.rs
@@ -1,0 +1,132 @@
+//! [Sophia] adapter for [Turtle].
+//!
+//! Example: count the number of of people using the `Sophia` API:
+//! ```
+//! use rio_api::model::NamedNode;
+//! use rio_turtle::sophia::TurtleParser;
+//! use sophia_api::parser::TripleParser;
+//! use sophia_api::triple::{Triple, stream::TripleSource};
+//! use sophia_api::term::term_eq;
+//! use sophia_api::ns::rdf;
+//!
+//! let file = b"@prefix schema: <http://schema.org/> .
+//! <http://example.com/foo> a schema:Person ;
+//!     schema:name  \"Foo\" .
+//! <http://example.com/bar> a schema:Person ;
+//!     schema:name  \"Bar\" .
+//! ";
+//!
+//! let schema_person = NamedNode { iri: "http://schema.org/Person" };
+//! let mut count = 0;
+//! TurtleParser::default()
+//!     .parse(file.as_ref())
+//!     .filter_triples(|t| term_eq(t.p(), &rdf::type_) && term_eq(t.o(), &schema_person))
+//!     .for_each_triple(|_| { count += 1; })
+//!     .unwrap();
+//! assert_eq!(2, count)
+//! ```
+//!
+//! [Sophia]: https://crates.io/crates/sophia
+//! [Turtle]: https://www.w3.org/TR/turtle/
+
+use crate::{TurtleError, TurtleParser as RioTurtleParser};
+use rio_api::parser::ParseError;
+use rio_api::sophia::StrictRioSource;
+use sophia_api::parser::{Location, TripleParser, WithLocation};
+use std::io::BufRead;
+
+/// An implementation of [`sophia_api::parser::TripleParser`]
+/// around [the turtle parser].
+///
+/// [`sophia_api::parser::TripleParser`]: https://docs.rs/sophia_api/latest/sophia_api/parser/trait.TripleParser.html
+/// [the turtle parser]: ../../struct.TurtleParser.html
+#[derive(Clone, Debug, Default)]
+pub struct TurtleParser {
+    pub base: Option<String>,
+}
+
+impl<B: BufRead> TripleParser<B> for TurtleParser {
+    type Source = StrictRioSource<RioTurtleParser<B>, TurtleError>;
+    fn parse(&self, data: B) -> Self::Source {
+        let base: &str = match &self.base {
+            Some(base) => &base,
+            None => "x-no-base:///",
+        };
+        StrictRioSource::from(RioTurtleParser::new(data, base))
+    }
+}
+
+impl WithLocation for TurtleError {
+    fn location(&self) -> Location {
+        match self.textual_position() {
+            None => Location::Unknown,
+            Some(pos) => Location::from_lico(pos.line_number() + 1, pos.byte_number() + 1),
+        }
+    }
+}
+
+sophia_api::def_mod_functions_for_bufread_parser!(TurtleParser, TripleParser);
+
+// ---------------------------------------------------------------------------------
+//                                      tests
+// ---------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rio_api::model::{Literal, NamedNode};
+    use sophia_api::graph::Graph;
+    use sophia_api::ns::rdf;
+    use sophia_api::term::matcher::ANY;
+    use sophia_api::term::test::TestTerm;
+    use sophia_api::triple::stream::TripleSource;
+
+    #[test]
+    fn test_simple_turtle_string() -> Result<(), Box<dyn std::error::Error>> {
+        let turtle = r#"
+            @prefix : <http://example.org/ns/> .
+
+            <#me> :knows [ a :Person ; :name "Alice" ].
+        "#;
+
+        let p = TurtleParser {
+            base: Some("http://localhost/ex".to_string()),
+        };
+
+        let g: Vec<[TestTerm<String>; 3]> = p.parse_str(&turtle).collect_triples()?;
+        assert_eq!(g.len(), 3);
+        assert!(g
+            .triples_matching(
+                &NamedNode {
+                    iri: "http://localhost/ex#me"
+                },
+                &NamedNode {
+                    iri: "http://example.org/ns/knows"
+                },
+                &ANY,
+            )
+            .next()
+            .is_some());
+        assert!(g
+            .triples_matching(
+                &ANY,
+                &rdf::type_,
+                &NamedNode {
+                    iri: "http://example.org/ns/Person"
+                },
+            )
+            .next()
+            .is_some());
+        assert!(g
+            .triples_matching(
+                &ANY,
+                &NamedNode {
+                    iri: "http://example.org/ns/name"
+                },
+                &Literal::Simple { value: "Alice" },
+            )
+            .next()
+            .is_some());
+        Ok(())
+    }
+}

--- a/xml/Cargo.toml
+++ b/xml/Cargo.toml
@@ -11,8 +11,20 @@ RDF/XML parser and serializer
 """
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 oxilangtag = "0.1"
 oxiri = "0.1"
 rio_api = "0.4"
 quick-xml = "0.18"
+sophia_api = { version = "0.6.1", optional = true }
+
+[dev-dependencies.sophia_api]
+version = "0.6.1"
+features = ["test_macro"]
+
+[features]
+default = []
+sophia = ["rio_api/sophia", "sophia_api"]

--- a/xml/src/lib.rs
+++ b/xml/src/lib.rs
@@ -51,3 +51,6 @@ mod parser;
 pub use error::RdfXmlError;
 pub use formatter::RdfXmlFormatter;
 pub use parser::RdfXmlParser;
+
+#[cfg(feature = "sophia")]
+pub mod sophia;

--- a/xml/src/lib.rs
+++ b/xml/src/lib.rs
@@ -53,4 +53,4 @@ pub use formatter::RdfXmlFormatter;
 pub use parser::RdfXmlParser;
 
 #[cfg(feature = "sophia")]
-pub mod sophia;
+mod sophia;

--- a/xml/src/sophia.rs
+++ b/xml/src/sophia.rs
@@ -1,0 +1,133 @@
+//! [Sophia] adapters for the [RDF/XML] parser.
+//!
+//! This module is available if feature `sophia` is enabled.
+//!
+//! Example: count the number of of people using the `Sophia` API:
+//! ```
+//! use rio_api::model::NamedNode;
+//! use rio_xml::sophia::RdfXmlParser;
+//! use sophia_api::parser::TripleParser;
+//! use sophia_api::triple::{Triple, stream::TripleSource};
+//! use sophia_api::term::term_eq;
+//! use sophia_api::ns::rdf;
+//!
+//! let file = b"<?xml version=\"1.0\"?>
+//! <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:schema=\"http://schema.org/\">
+//!  <rdf:Description rdf:about=\"http://example.com/foo\">
+//!    <rdf:type rdf:resource=\"http://schema.org/Person\" />
+//!    <schema:name>Foo</schema:name>
+//!  </rdf:Description>
+//!  <schema:Person rdf:about=\"http://example.com/bar\" schema:name=\"Bar\" />
+//! </rdf:RDF>";
+//!
+//! let schema_person = NamedNode { iri: "http://schema.org/Person" };
+//! let mut count = 0;
+//! RdfXmlParser::default()
+//!     .parse(file.as_ref())
+//!     .filter_triples(|t| term_eq(t.p(), &rdf::type_) && term_eq(t.o(), &schema_person))
+//!     .for_each_triple(|_| { count += 1; })
+//!     .unwrap();
+//! assert_eq!(2, count)
+//! ```
+//!
+//! [Sophia]: https://crates.io/crates/sophia
+//! [RDF/XML]: https://www.w3.org/TR/rdf-syntax-grammar/
+
+use crate::{RdfXmlError, RdfXmlParser as RioRdfXmlParser};
+use rio_api::sophia::*;
+use sophia_api::parser::TripleParser;
+use std::io::BufRead;
+
+/// An implementation of [`sophia_api::parser::TripleParser`]
+/// around [the RDF/XML parser].
+///
+/// [`sophia_api::parser::TripleParser`]: https://docs.rs/sophia_api/latest/sophia_api/parser/trait.TripleParser.html
+/// [the RDF/XML parser]: ../../struct.RdfXmlParser.html
+#[derive(Clone, Debug, Default)]
+pub struct RdfXmlParser {
+    pub base: Option<String>,
+}
+
+impl<B: BufRead> TripleParser<B> for RdfXmlParser {
+    type Source = StrictRioSource<RioRdfXmlParser<B>, RdfXmlError>;
+    fn parse(&self, data: B) -> Self::Source {
+        let base: &str = match &self.base {
+            Some(base) => &base,
+            None => "x-no-base:///",
+        };
+        StrictRioSource::from(RioRdfXmlParser::new(data, base))
+    }
+}
+
+sophia_api::def_mod_functions_for_bufread_parser!(RdfXmlParser, TripleParser);
+
+// ---------------------------------------------------------------------------------
+//                                      tests
+// ---------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rio_api::model::{Literal, NamedNode};
+    use sophia_api::graph::Graph;
+    use sophia_api::ns::rdf;
+    use sophia_api::term::matcher::ANY;
+    use sophia_api::term::test::TestTerm;
+    use sophia_api::triple::stream::TripleSource;
+
+    #[test]
+    fn test_simple_xml_string() -> Result<(), Box<dyn std::error::Error>> {
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                 xmlns="http://example.org/ns/">
+          <rdf:Description rdf:about="http://localhost/ex#me">
+            <knows>
+              <Person>
+                <name>Alice</name>
+              </Person>
+            </knows>
+          </rdf:Description>
+        </rdf:RDF>
+        "#;
+
+        let p = RdfXmlParser {
+            base: Some("http://localhost/ex".into()),
+        };
+
+        let g: Vec<[TestTerm<String>; 3]> = p.parse_str(&xml).collect_triples()?;
+        assert_eq!(g.len(), 3);
+        assert!(g
+            .triples_matching(
+                &NamedNode {
+                    iri: "http://localhost/ex#me"
+                },
+                &NamedNode {
+                    iri: "http://example.org/ns/knows"
+                },
+                &ANY,
+            )
+            .next()
+            .is_some());
+        assert!(g
+            .triples_matching(
+                &ANY,
+                &rdf::type_,
+                &NamedNode {
+                    iri: "http://example.org/ns/Person"
+                },
+            )
+            .next()
+            .is_some());
+        assert!(g
+            .triples_matching(
+                &ANY,
+                &NamedNode {
+                    iri: "http://example.org/ns/name"
+                },
+                &Literal::Simple { value: "Alice" },
+            )
+            .next()
+            .is_some());
+        Ok(())
+    }
+}


### PR DESCRIPTION
As we discussed previously, here is a PR adding [Sophia](https://crates.io/crates/sophia) compliance to Rio.

This is "hidden" behind the optional feature `sophia`,
so it will not have any impact on Rio users not interested in Sophia.