### PR TITLE
Uses oxiri::Iri for base_iri parameters

### DIFF
--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -16,11 +16,11 @@ rio_api = "0.4"
 rio_turtle = "0.4"
 rio_xml = "0.4"
 chrono = "0.4"
+oxiri = "0.1"
 permutohedron = "0.2"
 
 [dev-dependencies]
 criterion = "0.3"
-iref = "1"
 
 [features]
 default = ["generalized"]

--- a/testsuite/benches/w3c_testsuite.rs
+++ b/testsuite/benches/w3c_testsuite.rs
@@ -1,4 +1,5 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use oxiri::Iri;
 use rio_api::parser::*;
 use rio_testsuite::manifest::TestManifest;
 use rio_testsuite::parser_evaluator::*;
@@ -85,7 +86,6 @@ fn parse_ntriples(c: &mut Criterion, name: &str, data: Vec<u8>) {
     parse_bench(c, "ntriples", name, data, |data| {
         let mut count: usize = 0;
         NTriplesParser::new(data)
-            .unwrap()
             .parse_all(&mut |_| {
                 count += 1;
                 Ok(()) as Result<(), TurtleError>
@@ -98,7 +98,6 @@ fn parse_nquads(c: &mut Criterion, name: &str, data: Vec<u8>) {
     parse_bench(c, "nquads", name, data, |data| {
         let mut count: usize = 0;
         NQuadsParser::new(data)
-            .unwrap()
             .parse_all(&mut |_| {
                 count += 1;
                 Ok(()) as Result<(), TurtleError>
@@ -108,10 +107,10 @@ fn parse_nquads(c: &mut Criterion, name: &str, data: Vec<u8>) {
 }
 
 fn parse_turtle(c: &mut Criterion, name: &str, data: Vec<u8>) {
+    let base_iri = Iri::parse("http://example.com/ex".to_owned()).unwrap();
     parse_bench(c, "turtle", name, data, |data| {
         let mut count: usize = 0;
-        TurtleParser::new(data, "http://example.com/ex")
-            .unwrap()
+        TurtleParser::new(data, Some(base_iri.clone()))
             .parse_all(&mut |_| {
                 count += 1;
                 Ok(()) as Result<(), TurtleError>
@@ -121,10 +120,10 @@ fn parse_turtle(c: &mut Criterion, name: &str, data: Vec<u8>) {
 }
 
 fn parse_trig(c: &mut Criterion, name: &str, data: Vec<u8>) {
+    let base_iri = Iri::parse("http://example.com/ex".to_owned()).unwrap();
     parse_bench(c, "trig", name, data, |data| {
         let mut count: usize = 0;
-        TriGParser::new(data, "http://example.com/ex")
-            .unwrap()
+        TriGParser::new(data, Some(base_iri.clone()))
             .parse_all(&mut |_| {
                 count += 1;
                 Ok(()) as Result<(), TurtleError>
@@ -137,13 +136,15 @@ fn parse_trig(c: &mut Criterion, name: &str, data: Vec<u8>) {
 fn parse_gtrig(c: &mut Criterion, name: &str, data: Vec<u8>) {
     parse_bench(c, "gtrig", name, data, |data| {
         let mut count: usize = 0;
-        GTriGParser::new(data, "http://example.com/ex")
-            .unwrap()
-            .parse_all(&mut |_| {
-                count += 1;
-                Ok(()) as Result<(), TurtleError>
-            })
-            .unwrap();
+        GTriGParser::new(
+            data,
+            Some(Iri::parse("http://example.org/base/".to_owned()).unwrap()),
+        )
+        .parse_all(&mut |_| {
+            count += 1;
+            Ok(()) as Result<(), TurtleError>
+        })
+        .unwrap();
     });
 }
 

--- a/testsuite/src/parser_evaluator.rs
+++ b/testsuite/src/parser_evaluator.rs
@@ -3,6 +3,7 @@ use crate::manifest::{Test, TestManifestError};
 use crate::model::OwnedDataset;
 use crate::report::{TestOutcome, TestResult};
 use chrono::Utc;
+use oxiri::Iri;
 use rio_api::model::*;
 use rio_api::parser::*;
 use rio_turtle::*;
@@ -110,24 +111,25 @@ pub fn parse_w3c_rdf_test_file(
 ) -> Result<OwnedDataset, Box<dyn Error>> {
     let read = read_w3c_rdf_test_file(url, tests_path)?;
 
+    let base_iri = Iri::parse(url.to_owned())?;
     if url.ends_with(".nt") {
-        NTriplesParser::new(read)?
+        NTriplesParser::new(read)
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else if url.ends_with(".nq") {
-        NQuadsParser::new(read)?
+        NQuadsParser::new(read)
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else if url.ends_with(".ttl") {
-        TurtleParser::new(read, url)?
+        TurtleParser::new(read, Some(base_iri))
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else if url.ends_with(".trig") {
-        TriGParser::new(read, url)?
+        TriGParser::new(read, Some(base_iri))
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else if url.ends_with(".rdf") {
-        RdfXmlParser::new(read, url)?
+        RdfXmlParser::new(read, Some(base_iri))
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else {
@@ -143,21 +145,22 @@ pub fn parse_w3c_rdf_test_file_for_gtrig(
     tests_path: &Path,
 ) -> Result<OwnedDataset, Box<dyn Error>> {
     let read = read_w3c_rdf_test_file(url, tests_path)?;
+    let base_iri = Iri::parse(url.to_owned())?;
 
     if url.ends_with(".nt") {
-        NTriplesParser::new(read)?
+        NTriplesParser::new(read)
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else if url.ends_with(".nq") {
-        NQuadsParser::new(read)?
+        NQuadsParser::new(read)
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else if url.ends_with(".ttl") {
-        TurtleParser::new(read, url)?
+        TurtleParser::new(read, Some(base_iri))
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else if url.ends_with(".trig") {
-        GTriGParser::new(read, url)?
+        GTriGParser::new(read, Some(base_iri))
             .into_iter(|t| Ok(Quad::try_from(t)?.into()))
             .collect()
     } else {

--- a/testsuite/tests/rio_testsuite.rs
+++ b/testsuite/tests/rio_testsuite.rs
@@ -1,3 +1,4 @@
+use oxiri::Iri;
 use rio_api::parser::{QuadsParser, TriplesParser};
 use rio_testsuite::manifest::TestManifest;
 use rio_testsuite::model::OwnedDataset;
@@ -15,25 +16,26 @@ pub fn parse_rdf_test_file(url: &str) -> Result<OwnedDataset, Box<dyn Error>> {
         File::open(&url.replace("https://github.com/Tpt/rio/tests", &base))
             .map_err(|e| TestEvaluationError::IO(url.to_owned(), e))?,
     );
+    let base_iri = Iri::parse(url.to_owned())?;
 
     if url.ends_with(".nt") {
-        NTriplesParser::new(read)?
+        NTriplesParser::new(read)
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else if url.ends_with(".nq") {
-        NQuadsParser::new(read)?
+        NQuadsParser::new(read)
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else if url.ends_with(".ttl") {
-        TurtleParser::new(read, url)?
+        TurtleParser::new(read, Some(base_iri))
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else if url.ends_with(".trig") {
-        TriGParser::new(read, url)?
+        TriGParser::new(read, Some(base_iri))
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else if url.ends_with(".rdf") {
-        RdfXmlParser::new(read, url)?
+        RdfXmlParser::new(read, Some(base_iri))
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else {

--- a/testsuite/tests/serd_testsuite.rs
+++ b/testsuite/tests/serd_testsuite.rs
@@ -1,3 +1,4 @@
+use oxiri::Iri;
 use rio_api::parser::{QuadsParser, TriplesParser};
 use rio_testsuite::manifest::TestManifest;
 use rio_testsuite::model::OwnedDataset;
@@ -14,21 +15,22 @@ pub fn parse_rdf_test_file(url: &str) -> Result<OwnedDataset, Box<dyn Error>> {
         File::open(&url.replace("http://drobilla.net/sw/serd/tests", &base))
             .map_err(|e| TestEvaluationError::IO(url.to_owned(), e))?,
     );
+    let base_iri = Iri::parse(url.to_owned())?;
 
     if url.ends_with(".nt") {
-        NTriplesParser::new(read)?
+        NTriplesParser::new(read)
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else if url.ends_with(".nq") {
-        NQuadsParser::new(read)?
+        NQuadsParser::new(read)
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else if url.ends_with(".ttl") {
-        TurtleParser::new(read, url)?
+        TurtleParser::new(read, Some(base_iri))
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else if url.ends_with(".trig") {
-        TriGParser::new(read, url)?
+        TriGParser::new(read, Some(base_iri))
             .into_iter(|t| Ok(t.into()))
             .collect()
     } else {

--- a/turtle/src/ntriples.rs
+++ b/turtle/src/ntriples.rs
@@ -30,7 +30,7 @@ use std::io::BufRead;
 /// let rdf_type = NamedNode { iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" };
 /// let schema_person = NamedNode { iri: "http://schema.org/Person" };
 /// let mut count = 0;
-/// NTriplesParser::new(file.as_ref()).unwrap().parse_all(&mut |t| {
+/// NTriplesParser::new(file.as_ref()).parse_all(&mut |t| {
 ///     if t.predicate == rdf_type && t.object == schema_person.into() {
 ///         count += 1;
 ///     }
@@ -47,14 +47,14 @@ pub struct NTriplesParser<R: BufRead> {
 }
 
 impl<R: BufRead> NTriplesParser<R> {
-    pub fn new(reader: R) -> Result<Self, TurtleError> {
-        Ok(Self {
+    pub fn new(reader: R) -> Self {
+        Self {
             read: LookAheadByteReader::new(reader),
             subject_buf: String::default(),
             predicate_buf: String::default(),
             object_buf: String::default(),
             object_annotation_buf: String::default(),
-        })
+        }
     }
 }
 
@@ -117,7 +117,7 @@ impl<R: BufRead> TriplesParser for NTriplesParser<R> {
 /// let rdf_type = NamedNode { iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" };
 /// let schema_person = NamedNode { iri: "http://schema.org/Person" };
 /// let mut count = 0;
-/// NQuadsParser::new(file.as_ref()).unwrap().parse_all(&mut |t| {
+/// NQuadsParser::new(file.as_ref()).parse_all(&mut |t| {
 ///     if t.predicate == rdf_type && t.object == schema_person.into() {
 ///         count += 1;
 ///     }
@@ -135,15 +135,15 @@ pub struct NQuadsParser<R: BufRead> {
 }
 
 impl<R: BufRead> NQuadsParser<R> {
-    pub fn new(reader: R) -> Result<Self, TurtleError> {
-        Ok(Self {
+    pub fn new(reader: R) -> Self {
+        Self {
             read: LookAheadByteReader::new(reader),
             subject_buf: String::default(),
             predicate_buf: String::default(),
             object_buf: String::default(),
             object_annotation_buf: String::default(),
             graph_name_buf: String::default(),
-        })
+        }
     }
 }
 

--- a/turtle/src/turtle.rs
+++ b/turtle/src/turtle.rs
@@ -52,22 +52,9 @@ pub struct TurtleParser<R: BufRead> {
 
 impl<R: BufRead> TurtleParser<R> {
     /// Builds the parser from a `BufRead` implementation and a base IRI for relative IRI resolution.
-    ///
-    /// The base IRI might be empty to state there is no base IRI.
-    pub fn new(reader: R, base_iri: &str) -> Result<Self, TurtleError> {
-        let read = LookAheadByteReader::new(reader);
-        let base_iri = if base_iri.is_empty() {
-            None
-        } else {
-            Some(Iri::parse(base_iri.to_owned()).map_err(|error| {
-                read.parse_error(TurtleErrorKind::InvalidIri {
-                    iri: base_iri.to_owned(),
-                    error,
-                })
-            })?)
-        };
-        Ok(Self {
-            read,
+    pub fn new(reader: R, base_iri: Option<Iri<String>>) -> Self {
+        Self {
+            read: LookAheadByteReader::new(reader),
             base_iri,
             namespaces: HashMap::default(),
             bnode_id_generator: BlankNodeIdGenerator::default(),
@@ -76,7 +63,7 @@ impl<R: BufRead> TurtleParser<R> {
             predicate_buf_stack: StringBufferStack::default(),
             object_annotation_buf: String::default(),
             temp_buf: String::default(),
-        })
+        }
     }
 }
 
@@ -132,13 +119,11 @@ pub struct TriGParser<R: BufRead> {
 
 impl<R: BufRead> TriGParser<R> {
     /// Builds the parser from a `BufRead` implementation and a base IRI for relative IRI resolution.
-    ///
-    /// The base IRI might be empty to state there is no base URL.
-    pub fn new(reader: R, base_iri: &str) -> Result<Self, TurtleError> {
-        Ok(Self {
-            inner: TurtleParser::new(reader, base_iri)?,
+    pub fn new(reader: R, base_iri: Option<Iri<String>>) -> Self {
+        Self {
+            inner: TurtleParser::new(reader, base_iri),
             graph_name_buf: String::default(),
-        })
+        }
     }
 }
 

--- a/turtle/tests/recovery.rs
+++ b/turtle/tests/recovery.rs
@@ -8,7 +8,7 @@ fn ntriples_error_recovery() -> Result<(), TurtleError> {
 
     let mut count = 0;
     let mut count_err = 0;
-    let mut parser = NTriplesParser::new(Cursor::new(&data))?;
+    let mut parser = NTriplesParser::new(Cursor::new(&data));
     while !parser.is_end() {
         let step = parser.parse_step(&mut |_| {
             count += 1;
@@ -31,7 +31,7 @@ fn nquads_error_recovery() -> Result<(), TurtleError> {
 
     let mut count = 0;
     let mut count_err = 0;
-    let mut parser = NQuadsParser::new(Cursor::new(&data))?;
+    let mut parser = NQuadsParser::new(Cursor::new(&data));
     while !parser.is_end() {
         let step = parser.parse_step(&mut |_| {
             count += 1;

--- a/turtle/tests/rountrip.rs
+++ b/turtle/tests/rountrip.rs
@@ -15,7 +15,7 @@ fn ntriples_roundtrip() -> Result<(), TurtleError> {
     let nt = formatter.finish();
 
     let mut count = 0;
-    NTriplesParser::new(Cursor::new(&nt))?.parse_all(&mut |_| {
+    NTriplesParser::new(Cursor::new(&nt)).parse_all(&mut |_| {
         count += 1;
         Ok(()) as Result<(), TurtleError>
     })?;
@@ -36,7 +36,7 @@ fn nquads_roundtrip() -> Result<(), TurtleError> {
     let nt = formatter.finish();
 
     let mut count = 0;
-    NQuadsParser::new(Cursor::new(&nt))?.parse_all(&mut |_| {
+    NQuadsParser::new(Cursor::new(&nt)).parse_all(&mut |_| {
         count += 1;
         Ok(()) as Result<(), TurtleError>
     })?;
@@ -57,7 +57,7 @@ fn turtle_roundtrip() -> Result<(), TurtleError> {
     let turtle = formatter.finish()?;
 
     let mut count = 0;
-    TurtleParser::new(Cursor::new(&turtle), "")?.parse_all(&mut |_| {
+    TurtleParser::new(Cursor::new(&turtle), None).parse_all(&mut |_| {
         count += 1;
         Ok(()) as Result<(), TurtleError>
     })?;
@@ -78,7 +78,7 @@ fn trig_roundtrip() -> Result<(), TurtleError> {
     let trig = formatter.finish()?;
 
     let mut count = 0;
-    TriGParser::new(Cursor::new(&trig), "")?.parse_all(&mut |_| {
+    TriGParser::new(Cursor::new(&trig), None).parse_all(&mut |_| {
         count += 1;
         Ok(()) as Result<(), TurtleError>
     })?;
@@ -100,7 +100,7 @@ fn gtrig_roundtrip() -> Result<(), TurtleError> {
     let trig = formatter.finish()?;
 
     let mut count = 0;
-    GTriGParser::new(Cursor::new(&trig), "")?.parse_all(&mut |_| {
+    GTriGParser::new(Cursor::new(&trig), None).parse_all(&mut |_| {
         count += 1;
         Ok(()) as Result<(), TurtleError>
     })?;

--- a/xml/src/lib.rs
+++ b/xml/src/lib.rs
@@ -7,10 +7,11 @@
 //! use rio_api::model::NamedNode;
 //! use std::io::BufReader;
 //! use std::fs::File;
+//! use oxiri::Iri;
 //!
 //! let rdf_type = NamedNode { iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" };
 //! let mut count = 0;
-//! RdfXmlParser::new(BufReader::new(File::open("foo.rdf").unwrap()), "file:foo.rdf").unwrap().parse_all(&mut |t| {
+//! RdfXmlParser::new(BufReader::new(File::open("foo.rdf").unwrap()), Some(Iri::parse("file:foo.rdf".to_owned())).parse_all(&mut |t| {
 //!     if t.predicate == rdf_type {
 //!         count += 1;
 //!     }

--- a/xml/src/parser.rs
+++ b/xml/src/parser.rs
@@ -39,7 +39,7 @@ use std::collections::HashSet;
 /// let rdf_type = NamedNode { iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" };
 /// let schema_person = NamedNode { iri: "http://schema.org/Person" };
 /// let mut count = 0;
-/// RdfXmlParser::new(file.as_ref(), "").unwrap().parse_all(&mut |t| {
+/// RdfXmlParser::new(file.as_ref(), None).parse_all(&mut |t| {
 ///     if t.predicate == rdf_type && t.object == schema_person.into() {
 ///         count += 1;
 ///     }
@@ -55,22 +55,14 @@ pub struct RdfXmlParser<R: BufRead> {
 
 impl<R: BufRead> RdfXmlParser<R> {
     /// Builds the parser from a `BufRead` implementation and a base IRI for relative IRI resolution.
-    ///
-    /// The base IRI might be empty to state there is no base IRI.
-    pub fn new(reader: R, base_iri: &str) -> Result<Self, RdfXmlError> {
+    pub fn new(reader: R, base_iri: Option<Iri<String>>) -> Self {
         let mut reader = Reader::from_reader(reader);
         reader.expand_empty_elements(true);
         reader.trim_text(true);
-        Ok(Self {
+        Self {
             reader: RdfXmlReader {
                 reader,
-                state: vec![RdfXmlState::Doc {
-                    base_iri: if base_iri.is_empty() {
-                        None
-                    } else {
-                        Some(Iri::parse(base_iri.to_owned())?)
-                    },
-                }],
+                state: vec![RdfXmlState::Doc { base_iri }],
                 namespace_buffer: Vec::default(),
                 bnode_id_generator: BlankNodeIdGenerator::default(),
                 in_literal_depth: 0,
@@ -78,7 +70,7 @@ impl<R: BufRead> RdfXmlParser<R> {
             },
             reader_buffer: Vec::default(),
             is_end: false,
-        })
+        }
     }
 }
 

--- a/xml/tests/rountrip.rs
+++ b/xml/tests/rountrip.rs
@@ -70,7 +70,7 @@ fn simple_roundtrip() -> Result<(), RdfXmlError> {
     let xml = formatter.finish()?;
 
     let mut count = 0;
-    RdfXmlParser::new(Cursor::new(&xml), "")?.parse_all(&mut |_| {
+    RdfXmlParser::new(Cursor::new(&xml), None).parse_all(&mut |_| {
         count += 1;
         Ok(()) as Result<(), RdfXmlError>
     })?;


### PR DESCRIPTION
Allows to avoid returning a `Result` when building new parsers.