### PR TITLE
add more RDF* support in the API

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "testsuite/rdf-tests"]
 	path = testsuite/rdf-tests
 	url = https://github.com/w3c/rdf-tests.git
+[submodule "testsuite/rdf-star"]
+	path = testsuite/rdf-star
+	url = https://github.com/w3c/rdf-star/

--- a/api/src/model.rs
+++ b/api/src/model.rs
@@ -172,6 +172,16 @@ impl<'a> From<&'a Triple<'a>> for Subject<'a> {
     }
 }
 
+impl<'a> From<GraphName<'a>> for Subject<'a> {
+    #[inline]
+    fn from(node: GraphName<'a>) -> Self {
+        match node {
+            GraphName::BlankNode(node) => Subject::BlankNode(node),
+            GraphName::NamedNode(node) => Subject::NamedNode(node),
+        }
+    }
+}
+
 /// An RDF [term](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-term).
 ///
 /// It is the union of [IRIs](https://www.w3.org/TR/rdf11-concepts/#dfn-iri), [blank nodes](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node) and [literals](https://www.w3.org/TR/rdf11-concepts/#dfn-literal).

--- a/api/src/model.rs
+++ b/api/src/model.rs
@@ -141,7 +141,11 @@ impl<'a> fmt::Display for Subject<'a> {
             Subject::NamedNode(node) => node.fmt(f),
             Subject::BlankNode(node) => node.fmt(f),
             #[cfg(feature = "star")]
-            Subject::Triple(triple) => write!(f, "<< {} >>", triple),
+            Subject::Triple(triple) => write!(
+                f,
+                "<< {} {} {} >>",
+                triple.subject, triple.predicate, triple.object
+            ),
         }
     }
 }
@@ -191,7 +195,11 @@ impl<'a> fmt::Display for Term<'a> {
             Term::BlankNode(node) => node.fmt(f),
             Term::Literal(literal) => literal.fmt(f),
             #[cfg(feature = "star")]
-            Term::Triple(triple) => write!(f, "<< {} >>", triple),
+            Term::Triple(triple) => write!(
+                f,
+                "<< {} {} {} >>",
+                triple.subject, triple.predicate, triple.object
+            ),
         }
     }
 }

--- a/api/src/sophia.rs
+++ b/api/src/sophia.rs
@@ -86,20 +86,47 @@ impl<'a> TTerm for Literal<'a> {
     }
 }
 
-impl<'a> TTerm for NamedOrBlankNode<'a> {
+impl<'a> TTerm for Subject<'a> {
     #[inline]
     fn kind(&self) -> TermKind {
         match self {
-            NamedOrBlankNode::NamedNode(_) => TermKind::Iri,
-            NamedOrBlankNode::BlankNode(_) => TermKind::BlankNode,
+            Subject::NamedNode(_) => TermKind::Iri,
+            Subject::BlankNode(_) => TermKind::BlankNode,
+            #[cfg(feature = "star")]
+            Subject::Triple(_) => panic!("Sophia does not support RDF* yet"),
         }
     }
 
     #[inline]
     fn value_raw(&self) -> RawValue<'_> {
         match self {
-            NamedOrBlankNode::NamedNode(n) => n.value_raw(),
-            NamedOrBlankNode::BlankNode(n) => n.value_raw(),
+            Subject::NamedNode(n) => n.value_raw(),
+            Subject::BlankNode(n) => n.value_raw(),
+            #[cfg(feature = "star")]
+            Subject::Triple(_) => panic!("Sophia does not support RDF* yet"),
+        }
+    }
+
+    #[inline]
+    fn as_dyn(&self) -> &dyn TTerm {
+        self
+    }
+}
+
+impl<'a> TTerm for GraphName<'a> {
+    #[inline]
+    fn kind(&self) -> TermKind {
+        match self {
+            GraphName::NamedNode(_) => TermKind::Iri,
+            GraphName::BlankNode(_) => TermKind::BlankNode,
+        }
+    }
+
+    #[inline]
+    fn value_raw(&self) -> RawValue<'_> {
+        match self {
+            GraphName::NamedNode(n) => n.value_raw(),
+            GraphName::BlankNode(n) => n.value_raw(),
         }
     }
 

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-rio_api = { version = "0.5", path="../api", features=["star"] }
+rio_api = { version = "0.5", path="../api" }
 rio_turtle = { version = "0.5", path="../turtle" }
 rio_xml = { version = "0.5", path="../xml" }
 chrono = "0.4"
@@ -23,8 +23,9 @@ permutohedron = "0.2"
 criterion = "0.3"
 
 [features]
-default = ["generalized"]
+default = []
 generalized = ["rio_api/generalized", "rio_turtle/generalized"]
+star = ["rio_api/star", "rio_turtle/star" ]
 
 [[bench]]
 name = "w3c_testsuite"

--- a/testsuite/src/main.rs
+++ b/testsuite/src/main.rs
@@ -14,7 +14,9 @@ fn main() {
         eprintln!("Expecting two arguments: <w3c_rdf_tests_base_path> <manifest_url>");
         return;
     }
+    #[allow(unused_mut)]
     let mut parse_func: ParseFunction = parse_w3c_rdf_test_file;
+    #[allow(unused_mut)]
     let mut manifest_url = match args[2].as_ref() {
         "ntriples" | "nt" => "http://w3c.github.io/rdf-tests/ntriples/manifest.ttl",
         "nquads" | "nq" => "http://w3c.github.io/rdf-tests/nquads/manifest.ttl",

--- a/testsuite/src/model.rs
+++ b/testsuite/src/model.rs
@@ -161,7 +161,7 @@ impl fmt::Display for OwnedSubject {
             OwnedSubject::NamedNode(n) => n.fmt(f),
             OwnedSubject::BlankNode(n) => n.fmt(f),
             #[cfg(feature = "star")]
-            OwnedSubject::Triple(t) => t.fmt(f),
+            OwnedSubject::Triple(t) => write!(f, "<< {} >>", t),
         }
     }
 }
@@ -278,7 +278,7 @@ impl fmt::Display for OwnedTerm {
             OwnedTerm::BlankNode(n) => n.fmt(f),
             OwnedTerm::Literal(n) => n.fmt(f),
             #[cfg(feature = "star")]
-            OwnedTerm::Triple(t) => t.fmt(f),
+            OwnedTerm::Triple(t) => write!(f, "<< {} >>", t),
         }
     }
 }

--- a/testsuite/src/model.rs
+++ b/testsuite/src/model.rs
@@ -28,6 +28,12 @@ impl<'a> From<&'a OwnedNamedNode> for NamedNode<'a> {
     }
 }
 
+impl PartialEq<OwnedNamedNode> for NamedNode<'_> {
+    fn eq(&self, other: &OwnedNamedNode) -> bool {
+        self.iri == other.iri
+    }
+}
+
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Hash)]
 pub struct OwnedBlankNode {
     pub id: String,
@@ -50,6 +56,12 @@ impl From<BlankNode<'_>> for OwnedBlankNode {
 impl<'a> From<&'a OwnedBlankNode> for BlankNode<'a> {
     fn from(n: &'a OwnedBlankNode) -> Self {
         Self { id: &n.id }
+    }
+}
+
+impl PartialEq<OwnedBlankNode> for BlankNode<'_> {
+    fn eq(&self, other: &OwnedBlankNode) -> bool {
+        self.id == other.id
     }
 }
 
@@ -112,45 +124,141 @@ impl<'a> From<&'a OwnedLiteral> for Literal<'a> {
     }
 }
 
+impl PartialEq<OwnedLiteral> for Literal<'_> {
+    fn eq(&self, other: &OwnedLiteral) -> bool {
+        match (self, other) {
+            (Literal::Simple { value }, OwnedLiteral::Simple { value: v2 }) => value == v2,
+            (
+                Literal::LanguageTaggedString { value, language },
+                OwnedLiteral::LanguageTaggedString {
+                    value: v2,
+                    language: l2,
+                },
+            ) => value == v2 && language == l2,
+            (
+                Literal::Typed { value, datatype },
+                OwnedLiteral::Typed {
+                    value: v2,
+                    datatype: d2,
+                },
+            ) => value == v2 && datatype == d2,
+            _ => false,
+        }
+    }
+}
+
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Hash)]
-pub enum OwnedNamedOrBlankNode {
+pub enum OwnedSubject {
+    NamedNode(OwnedNamedNode),
+    BlankNode(OwnedBlankNode),
+    #[cfg(feature = "star")]
+    Triple(Box<OwnedTriple>),
+}
+
+impl fmt::Display for OwnedSubject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OwnedSubject::NamedNode(n) => n.fmt(f),
+            OwnedSubject::BlankNode(n) => n.fmt(f),
+            #[cfg(feature = "star")]
+            OwnedSubject::Triple(t) => t.fmt(f),
+        }
+    }
+}
+
+impl From<Subject<'_>> for OwnedSubject {
+    fn from(t: Subject<'_>) -> Self {
+        match t {
+            Subject::NamedNode(n) => OwnedSubject::NamedNode(n.into()),
+            Subject::BlankNode(n) => OwnedSubject::BlankNode(n.into()),
+            #[cfg(feature = "star")]
+            Subject::Triple(t) => OwnedSubject::Triple(Box::new(OwnedTriple::from(*t))),
+            _ => panic!("Unsupported subject {:?}", t),
+        }
+    }
+}
+
+impl PartialEq<OwnedSubject> for Subject<'_> {
+    fn eq(&self, other: &OwnedSubject) -> bool {
+        match (self, other) {
+            (Subject::NamedNode(n1), OwnedSubject::NamedNode(n2)) => n1 == n2,
+            (Subject::BlankNode(n1), OwnedSubject::BlankNode(n2)) => n1 == n2,
+            #[cfg(feature = "star")]
+            (Subject::Triple(t1), OwnedSubject::Triple(t2)) => *t1 == &**t2,
+            _ => false,
+        }
+    }
+}
+
+impl From<OwnedNamedNode> for OwnedSubject {
+    fn from(node: OwnedNamedNode) -> Self {
+        OwnedSubject::NamedNode(node)
+    }
+}
+
+impl From<OwnedBlankNode> for OwnedSubject {
+    fn from(node: OwnedBlankNode) -> Self {
+        OwnedSubject::BlankNode(node)
+    }
+}
+
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Hash)]
+pub enum OwnedGraphName {
     NamedNode(OwnedNamedNode),
     BlankNode(OwnedBlankNode),
 }
 
-impl fmt::Display for OwnedNamedOrBlankNode {
+impl fmt::Display for OwnedGraphName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        NamedOrBlankNode::from(self).fmt(f)
+        GraphName::from(self).fmt(f)
     }
 }
 
-impl From<NamedOrBlankNode<'_>> for OwnedNamedOrBlankNode {
-    fn from(t: NamedOrBlankNode<'_>) -> Self {
+impl From<GraphName<'_>> for OwnedGraphName {
+    fn from(t: GraphName<'_>) -> Self {
         match t {
-            NamedOrBlankNode::NamedNode(n) => OwnedNamedOrBlankNode::NamedNode(n.into()),
-            NamedOrBlankNode::BlankNode(n) => OwnedNamedOrBlankNode::BlankNode(n.into()),
+            GraphName::NamedNode(n) => OwnedGraphName::NamedNode(n.into()),
+            GraphName::BlankNode(n) => OwnedGraphName::BlankNode(n.into()),
         }
     }
 }
 
-impl<'a> From<&'a OwnedNamedOrBlankNode> for NamedOrBlankNode<'a> {
-    fn from(t: &'a OwnedNamedOrBlankNode) -> Self {
+impl<'a> From<&'a OwnedGraphName> for GraphName<'a> {
+    fn from(t: &'a OwnedGraphName) -> Self {
         match t {
-            OwnedNamedOrBlankNode::NamedNode(n) => NamedOrBlankNode::NamedNode(n.into()),
-            OwnedNamedOrBlankNode::BlankNode(n) => NamedOrBlankNode::BlankNode(n.into()),
+            OwnedGraphName::NamedNode(n) => GraphName::NamedNode(n.into()),
+            OwnedGraphName::BlankNode(n) => GraphName::BlankNode(n.into()),
         }
     }
 }
 
-impl From<OwnedNamedNode> for OwnedNamedOrBlankNode {
+impl From<OwnedNamedNode> for OwnedGraphName {
     fn from(node: OwnedNamedNode) -> Self {
-        OwnedNamedOrBlankNode::NamedNode(node)
+        OwnedGraphName::NamedNode(node)
     }
 }
 
-impl From<OwnedBlankNode> for OwnedNamedOrBlankNode {
+impl From<OwnedBlankNode> for OwnedGraphName {
     fn from(node: OwnedBlankNode) -> Self {
-        OwnedNamedOrBlankNode::BlankNode(node)
+        OwnedGraphName::BlankNode(node)
+    }
+}
+
+impl PartialEq<OwnedGraphName> for GraphName<'_> {
+    fn eq(&self, other: &OwnedGraphName) -> bool {
+        match (self, other) {
+            (GraphName::NamedNode(n1), OwnedGraphName::NamedNode(n2)) => n1 == n2,
+            (GraphName::BlankNode(n1), OwnedGraphName::BlankNode(n2)) => n1 == n2,
+            _ => false,
+        }
+    }
+}
+
+fn same_graph_name(gn1: &Option<GraphName<'_>>, gn2: &Option<OwnedGraphName>) -> bool {
+    match (gn1, gn2) {
+        (Some(n1), Some(n2)) => n1 == n2,
+        (None, None) => true,
+        _ => false,
     }
 }
 
@@ -159,11 +267,19 @@ pub enum OwnedTerm {
     NamedNode(OwnedNamedNode),
     BlankNode(OwnedBlankNode),
     Literal(OwnedLiteral),
+    #[cfg(feature = "star")]
+    Triple(Box<OwnedTriple>),
 }
 
 impl fmt::Display for OwnedTerm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Term::from(self).fmt(f)
+        match self {
+            OwnedTerm::NamedNode(n) => n.fmt(f),
+            OwnedTerm::BlankNode(n) => n.fmt(f),
+            OwnedTerm::Literal(n) => n.fmt(f),
+            #[cfg(feature = "star")]
+            OwnedTerm::Triple(t) => t.fmt(f),
+        }
     }
 }
 
@@ -173,17 +289,9 @@ impl From<Term<'_>> for OwnedTerm {
             Term::NamedNode(n) => OwnedTerm::NamedNode(n.into()),
             Term::BlankNode(n) => OwnedTerm::BlankNode(n.into()),
             Term::Literal(n) => OwnedTerm::Literal(n.into()),
-            Term::Triple(_) => unimplemented!(),
-        }
-    }
-}
-
-impl<'a> From<&'a OwnedTerm> for Term<'a> {
-    fn from(t: &'a OwnedTerm) -> Self {
-        match t {
-            OwnedTerm::NamedNode(n) => Term::NamedNode(n.into()),
-            OwnedTerm::BlankNode(n) => Term::BlankNode(n.into()),
-            OwnedTerm::Literal(n) => Term::Literal(n.into()),
+            #[cfg(feature = "star")]
+            Term::Triple(t) => OwnedTerm::Triple(Box::new(OwnedTriple::from(*t))),
+            _ => panic!("Unsupported subject {:?}", t),
         }
     }
 }
@@ -206,27 +314,79 @@ impl From<OwnedLiteral> for OwnedTerm {
     }
 }
 
-impl From<OwnedNamedOrBlankNode> for OwnedTerm {
-    fn from(resource: OwnedNamedOrBlankNode) -> Self {
-        match resource {
-            OwnedNamedOrBlankNode::NamedNode(node) => OwnedTerm::NamedNode(node),
-            OwnedNamedOrBlankNode::BlankNode(node) => OwnedTerm::BlankNode(node),
+impl From<OwnedSubject> for OwnedTerm {
+    fn from(other: OwnedSubject) -> Self {
+        match other {
+            OwnedSubject::NamedNode(node) => OwnedTerm::NamedNode(node),
+            OwnedSubject::BlankNode(node) => OwnedTerm::BlankNode(node),
+            #[cfg(feature = "star")]
+            OwnedSubject::Triple(triple) => OwnedTerm::Triple(triple),
         }
+    }
+}
+
+impl PartialEq<OwnedTerm> for Term<'_> {
+    fn eq(&self, other: &OwnedTerm) -> bool {
+        match (self, other) {
+            (Term::NamedNode(n1), OwnedTerm::NamedNode(n2)) => n1 == n2,
+            (Term::BlankNode(n1), OwnedTerm::BlankNode(n2)) => n1 == n2,
+            (Term::Literal(n1), OwnedTerm::Literal(n2)) => n1 == n2,
+            #[cfg(feature = "star")]
+            (Term::Triple(t1), OwnedTerm::Triple(t2)) => *t1 == &**t2,
+            _ => false,
+        }
+    }
+}
+
+/// A [RDF triple](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple)
+#[derive(Eq, PartialEq, Debug, Clone, Hash, Ord, PartialOrd)]
+pub struct OwnedTriple {
+    pub subject: OwnedSubject,
+    pub predicate: OwnedNamedNode,
+    pub object: OwnedTerm,
+}
+
+impl fmt::Display for OwnedTriple {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {} {}", self.subject, self.predicate, self.object)
+    }
+}
+
+impl From<Triple<'_>> for OwnedTriple {
+    fn from(t: Triple<'_>) -> Self {
+        Self {
+            subject: t.subject.into(),
+            predicate: t.predicate.into(),
+            object: t.object.into(),
+        }
+    }
+}
+
+impl PartialEq<OwnedTriple> for Triple<'_> {
+    fn eq(&self, other: &OwnedTriple) -> bool {
+        self.subject == other.subject
+            && self.predicate == other.predicate
+            && self.object == other.object
     }
 }
 
 /// A [RDF triple](https://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple)
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct OwnedQuad {
-    pub subject: OwnedNamedOrBlankNode,
+    pub subject: OwnedSubject,
     pub predicate: OwnedNamedNode,
     pub object: OwnedTerm,
-    pub graph_name: Option<OwnedNamedOrBlankNode>,
+    pub graph_name: Option<OwnedGraphName>,
 }
 
 impl fmt::Display for OwnedQuad {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Quad::from(self).fmt(f)
+        write!(f, "{} {} {}", self.subject, self.predicate, self.object)?;
+        if let Some(n) = &self.graph_name {
+            ' '.fmt(f)?;
+            n.fmt(f)?;
+        }
+        Ok(())
     }
 }
 
@@ -252,14 +412,12 @@ impl From<Quad<'_>> for OwnedQuad {
     }
 }
 
-impl<'a> From<&'a OwnedQuad> for Quad<'a> {
-    fn from(q: &'a OwnedQuad) -> Self {
-        Self {
-            subject: (&q.subject).into(),
-            predicate: (&q.predicate).into(),
-            object: (&q.object).into(),
-            graph_name: q.graph_name.as_ref().map(|g| g.into()),
-        }
+impl PartialEq<OwnedQuad> for Quad<'_> {
+    fn eq(&self, other: &OwnedQuad) -> bool {
+        self.subject == other.subject
+            && self.predicate == other.predicate
+            && self.object == other.object
+            && same_graph_name(&self.graph_name, &other.graph_name)
     }
 }
 
@@ -289,39 +447,38 @@ impl OwnedDataset {
         self.inner.contains(t)
     }
 
-    pub fn triples_for_subject<'a>(
+    pub fn triples_for_subject<'a, T>(
         &'a self,
-        subject: impl Into<NamedOrBlankNode<'a>>,
-    ) -> impl Iterator<Item = &'a OwnedQuad> + 'a {
-        let subject: NamedOrBlankNode<'_> = subject.into();
-        self.inner
-            .iter()
-            .filter(move |t| NamedOrBlankNode::from(&t.subject) == subject)
+        subject: &'a T,
+    ) -> impl Iterator<Item = &'a OwnedQuad> + 'a
+    where
+        T: PartialEq<OwnedSubject> + 'a,
+    {
+        self.inner.iter().filter(move |t| subject == &t.subject)
     }
 
-    pub fn triples_for_object<'a>(
+    pub fn triples_for_object<'a, T>(
         &'a self,
-        object: impl Into<Term<'a>>,
-    ) -> impl Iterator<Item = &'a OwnedQuad> + 'a {
-        let object: Term<'_> = object.into();
-        self.inner
-            .iter()
-            .filter(move |t| Term::from(&t.object) == object)
+        object: &'a T,
+    ) -> impl Iterator<Item = &'a OwnedQuad> + 'a
+    where
+        T: PartialEq<OwnedTerm> + 'a,
+    {
+        self.inner.iter().filter(move |t| *object == t.object)
     }
 
-    pub fn object_for_subject_predicate<'a>(
+    pub fn object_for_subject_predicate<'a, T, U>(
         &'a self,
-        subject: impl Into<NamedOrBlankNode<'a>>,
-        predicate: impl Into<NamedNode<'a>>,
-    ) -> Option<&'a OwnedTerm> {
-        let subject: NamedOrBlankNode<'_> = subject.into();
-        let predicate: NamedNode<'_> = predicate.into();
+        subject: &T,
+        predicate: &U,
+    ) -> Option<&'a OwnedTerm>
+    where
+        T: PartialEq<OwnedSubject> + 'a,
+        U: PartialEq<OwnedNamedNode> + 'a,
+    {
         self.inner
             .iter()
-            .filter(move |t| {
-                NamedOrBlankNode::from(&t.subject) == subject
-                    && NamedNode::from(&t.predicate) == predicate
-            })
+            .filter(move |t| subject == &t.subject && predicate == &t.predicate)
             .map(|t| &t.object)
             .next()
     }

--- a/testsuite/src/model.rs
+++ b/testsuite/src/model.rs
@@ -482,6 +482,22 @@ impl OwnedDataset {
             .map(|t| &t.object)
             .next()
     }
+
+    pub fn subject_for_predicate_object<'a, T, U>(
+        &'a self,
+        predicate: &T,
+        object: &U,
+    ) -> Option<&'a OwnedSubject>
+    where
+        T: PartialEq<OwnedNamedNode> + 'a,
+        U: PartialEq<OwnedTerm> + 'a,
+    {
+        self.inner
+            .iter()
+            .filter(move |t| predicate == &t.predicate && object == &t.object)
+            .map(|t| &t.subject)
+            .next()
+    }
 }
 
 impl IntoIterator for OwnedDataset {

--- a/testsuite/src/parser_evaluator.rs
+++ b/testsuite/src/parser_evaluator.rs
@@ -96,6 +96,8 @@ pub fn read_w3c_rdf_test_file(
         Ok(url.replace("http://w3c.github.io/rdf-tests/", ""))
     } else if url.starts_with("http://www.w3.org/2013/RDFXMLTests/") {
         Ok(url.replace("http://www.w3.org/2013/RDFXMLTests/", "rdf-xml/"))
+    } else if url.starts_with("https://w3c.github.io/rdf-star/") {
+        Ok(url.replace("https://w3c.github.io/rdf-star/", "../rdf-star/"))
     } else {
         Err(Box::new(TestEvaluationError::UnknownTestUrl(
             url.to_owned(),

--- a/testsuite/src/parser_evaluator.rs
+++ b/testsuite/src/parser_evaluator.rs
@@ -4,10 +4,12 @@ use crate::model::OwnedDataset;
 use crate::report::{TestOutcome, TestResult};
 use chrono::Utc;
 use oxiri::Iri;
+#[cfg(feature = "generalized")]
 use rio_api::model::*;
 use rio_api::parser::*;
 use rio_turtle::*;
 use rio_xml::RdfXmlParser;
+#[cfg(feature = "generalized")]
 use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;

--- a/testsuite/src/vocab.rs
+++ b/testsuite/src/vocab.rs
@@ -7,6 +7,9 @@ pub mod mf {
     pub const ENTRIES: NamedNode<'static> = NamedNode {
         iri: "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#entries",
     };
+    pub const MANIFEST: NamedNode<'static> = NamedNode {
+        iri: "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#Manifest",
+    };
     pub const NAME: NamedNode<'static> = NamedNode {
         iri: "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name",
     };

--- a/testsuite/tests/w3c_testsuite.rs
+++ b/testsuite/tests/w3c_testsuite.rs
@@ -12,11 +12,16 @@ fn get_test_path() -> PathBuf {
 
 fn run_testsuite(manifest_uri: String) -> Result<(), Box<dyn Error>> {
     let test_path = get_test_path();
-    let manifest = TestManifest::new(manifest_uri, |url| parse_w3c_rdf_test_file(url, &test_path));
+    let manifest = TestManifest::new(manifest_uri.clone(), |url| {
+        parse_w3c_rdf_test_file(url, &test_path)
+    });
 
     let results = evaluate_parser_tests(manifest, |url| parse_w3c_rdf_test_file(url, &test_path))?;
 
     let mut errors = Vec::default();
+    if results.is_empty() {
+        errors.push(format!("<{}>: no entry found", &manifest_uri));
+    }
     for result in results {
         if let TestOutcome::Failed { error } = result.outcome {
             errors.push(format!("{}: failed with error {}", result.test, error))

--- a/testsuite/tests/w3c_testsuite.rs
+++ b/testsuite/tests/w3c_testsuite.rs
@@ -1,4 +1,5 @@
 use rio_testsuite::manifest::TestManifest;
+use rio_testsuite::model::OwnedDataset;
 use rio_testsuite::parser_evaluator::*;
 use rio_testsuite::report::TestOutcome;
 use std::error::Error;
@@ -10,17 +11,22 @@ fn get_test_path() -> PathBuf {
     base_path
 }
 
-fn run_testsuite(manifest_uri: String) -> Result<(), Box<dyn Error>> {
+fn run_testsuite(manifest_uri: &str) -> Result<(), Box<dyn Error>> {
     let test_path = get_test_path();
-    let manifest = TestManifest::new(manifest_uri.clone(), |url| {
-        parse_w3c_rdf_test_file(url, &test_path)
-    });
+    run_testsuite_with(manifest_uri, |url| parse_w3c_rdf_test_file(url, &test_path))
+}
 
-    let results = evaluate_parser_tests(manifest, |url| parse_w3c_rdf_test_file(url, &test_path))?;
+fn run_testsuite_with<R>(manifest_uri: &str, file_reader: R) -> Result<(), Box<dyn Error>>
+where
+    R: Fn(&str) -> Result<OwnedDataset, Box<dyn Error>>,
+{
+    let manifest = TestManifest::new(manifest_uri.to_owned(), &file_reader);
+
+    let results = evaluate_parser_tests(manifest, &file_reader)?;
 
     let mut errors = Vec::default();
     if results.is_empty() {
-        errors.push(format!("<{}>: no entry found", &manifest_uri));
+        errors.push(format!("<{}>: no entry found", manifest_uri));
     }
     for result in results {
         if let TestOutcome::Failed { error } = result.outcome {
@@ -34,55 +40,45 @@ fn run_testsuite(manifest_uri: String) -> Result<(), Box<dyn Error>> {
 
 #[test]
 fn ntriples_w3c_testsuite() -> Result<(), Box<dyn Error>> {
-    run_testsuite("http://w3c.github.io/rdf-tests/ntriples/manifest.ttl".to_owned())
-}
-
-#[test]
-fn nquads_w3c_testsuite() -> Result<(), Box<dyn Error>> {
-    run_testsuite("http://w3c.github.io/rdf-tests/nquads/manifest.ttl".to_owned())
+    run_testsuite("http://w3c.github.io/rdf-tests/ntriples/manifest.ttl")
 }
 
 #[test]
 fn turtle_w3c_testsuite() -> Result<(), Box<dyn Error>> {
-    run_testsuite("http://w3c.github.io/rdf-tests/turtle/manifest.ttl".to_owned())
+    run_testsuite("http://w3c.github.io/rdf-tests/turtle/manifest.ttl")
 }
 
 #[test]
 fn trig_w3c_testsuite() -> Result<(), Box<dyn Error>> {
-    run_testsuite("http://w3c.github.io/rdf-tests/trig/manifest.ttl".to_owned())
+    run_testsuite("http://w3c.github.io/rdf-tests/trig/manifest.ttl")
 }
 
 #[test]
 fn rdf_xml_w3c_testsuite() -> Result<(), Box<dyn Error>> {
-    run_testsuite("http://www.w3.org/2013/RDFXMLTests/manifest.ttl".to_owned())
+    run_testsuite("http://www.w3.org/2013/RDFXMLTests/manifest.ttl")
 }
 
 #[cfg(feature = "star")]
 #[test]
 fn ntriples_star_w3c_testsuite() -> Result<(), Box<dyn Error>> {
-    run_testsuite("https://w3c.github.io/rdf-star/tests/nt/syntax/manifest.ttl".to_owned())
+    run_testsuite("https://w3c.github.io/rdf-star/tests/nt/syntax/manifest.ttl")
+}
+
+#[cfg(feature = "star")]
+#[test]
+fn nquads_star_w3c_testsuite() -> Result<(), Box<dyn Error>> {
+    let test_path = get_test_path();
+    run_testsuite_with(
+        "https://w3c.github.io/rdf-star/tests/nt/syntax/manifest.ttl",
+        |url| parse_w3c_rdf_test_file_for_nquads(url, &test_path),
+    )
 }
 
 #[cfg(feature = "generalized")]
 #[test]
 fn gtrig_w3c_testsuite() -> Result<(), Box<dyn Error>> {
-    let manifest_uri = "http://w3c.github.io/rdf-tests/trig/manifest.ttl".to_owned();
     let test_path = get_test_path();
-    let manifest = TestManifest::new(manifest_uri, |url| {
+    run_testsuite_with("http://w3c.github.io/rdf-tests/trig/manifest.ttl", |url| {
         parse_w3c_rdf_test_file_for_gtrig(url, &test_path)
-    });
-
-    let results = evaluate_parser_tests(manifest, |url| {
-        parse_w3c_rdf_test_file_for_gtrig(url, &test_path)
-    })?;
-
-    let mut errors = Vec::default();
-    for result in results {
-        if let TestOutcome::Failed { error } = result.outcome {
-            errors.push(format!("{}: failed with error {}", result.test, error))
-        }
-    }
-
-    assert!(errors.is_empty(), "\n{}\n", errors.join("\n"));
-    Ok(())
+    })
 }

--- a/testsuite/tests/w3c_testsuite.rs
+++ b/testsuite/tests/w3c_testsuite.rs
@@ -52,6 +52,7 @@ fn rdf_xml_w3c_testsuite() -> Result<(), Box<dyn Error>> {
     run_testsuite("http://www.w3.org/2013/RDFXMLTests/manifest.ttl".to_owned())
 }
 
+#[cfg(feature = "generalized")]
 #[test]
 fn gtrig_w3c_testsuite() -> Result<(), Box<dyn Error>> {
     let manifest_uri = "http://w3c.github.io/rdf-tests/trig/manifest.ttl".to_owned();

--- a/testsuite/tests/w3c_testsuite.rs
+++ b/testsuite/tests/w3c_testsuite.rs
@@ -52,6 +52,12 @@ fn rdf_xml_w3c_testsuite() -> Result<(), Box<dyn Error>> {
     run_testsuite("http://www.w3.org/2013/RDFXMLTests/manifest.ttl".to_owned())
 }
 
+#[cfg(feature = "star")]
+#[test]
+fn ntriples_star_w3c_testsuite() -> Result<(), Box<dyn Error>> {
+    run_testsuite("https://w3c.github.io/rdf-star/tests/nt/syntax/manifest.ttl".to_owned())
+}
+
 #[cfg(feature = "generalized")]
 #[test]
 fn gtrig_w3c_testsuite() -> Result<(), Box<dyn Error>> {

--- a/testsuite/tests/w3c_testsuite.rs
+++ b/testsuite/tests/w3c_testsuite.rs
@@ -74,6 +74,22 @@ fn nquads_star_w3c_testsuite() -> Result<(), Box<dyn Error>> {
     )
 }
 
+#[cfg(feature = "star")]
+#[test]
+fn turtle_star_w3c_testsuite() -> Result<(), Box<dyn Error>> {
+    run_testsuite("https://w3c.github.io/rdf-star/tests/turtle/syntax/manifest.ttl")?;
+    run_testsuite("https://w3c.github.io/rdf-star/tests/turtle/eval/manifest.ttl")?;
+    Ok(())
+}
+
+#[cfg(feature = "star")]
+#[test]
+fn trig_star_w3c_testsuite() -> Result<(), Box<dyn Error>> {
+    run_testsuite("https://w3c.github.io/rdf-star/tests/trig/syntax/manifest.ttl")?;
+    run_testsuite("https://w3c.github.io/rdf-star/tests/trig/eval/manifest.ttl")?;
+    Ok(())
+}
+
 #[cfg(feature = "generalized")]
 #[test]
 fn gtrig_w3c_testsuite() -> Result<(), Box<dyn Error>> {

--- a/turtle/Cargo.toml
+++ b/turtle/Cargo.toml
@@ -18,6 +18,7 @@ all-features = true
 default = []
 generalized = ["rio_api/generalized"]
 sophia = ["rio_api/sophia", "sophia_api"]
+star = ["rio_api/star"]
 
 [dependencies]
 oxilangtag = "0.1"

--- a/turtle/src/gtrig.rs
+++ b/turtle/src/gtrig.rs
@@ -970,7 +970,7 @@ mod test {
                     value: n.name.to_string(),
                     extra: String::new(),
                 },
-                _ => unimplemented!(),
+                _ => panic!("unsupported term kind {:?}", other),
             }
         }
     }

--- a/turtle/src/lib.rs
+++ b/turtle/src/lib.rs
@@ -46,6 +46,7 @@ mod error;
 mod formatters;
 mod ntriples;
 mod shared;
+mod triple_allocator;
 mod turtle;
 mod utils;
 

--- a/turtle/src/triple_allocator.rs
+++ b/turtle/src/triple_allocator.rs
@@ -36,6 +36,21 @@ impl TripleAllocator {
         &self.complete_stack[self.complete_len - 1]
     }
 
+    pub fn top_quad<'s>(&'s self, graph_name: Option<GraphName<'s>>) -> Quad<'s> {
+        debug_assert!(self.complete_len > 0);
+        let Triple {
+            subject,
+            predicate,
+            object,
+        } = *self.top();
+        Quad {
+            subject,
+            predicate,
+            object,
+            graph_name,
+        }
+    }
+
     pub fn push_triple_start(&mut self) {
         if self.incomplete_len == self.incomplete_stack.len() {
             self.incomplete_stack.push(Triple {

--- a/turtle/src/triple_allocator.rs
+++ b/turtle/src/triple_allocator.rs
@@ -69,7 +69,10 @@ impl TripleAllocator {
         debug_assert!(dummy(self.current().subject));
         let buffer = self.string_stack.push();
         let subject = subject_factory(buffer)?;
-        debug_assert!(matches!(subject, Subject::NamedNode(_) | Subject::BlankNode(_)));
+        debug_assert!(matches!(
+            subject,
+            Subject::NamedNode(_) | Subject::BlankNode(_)
+        ));
         let subject: Subject<'static> = unsafe { transmute(subject) };
         // The unsafe code above changes the lifetime parameter of subject to `'static`.
         // This is ok because:
@@ -110,7 +113,10 @@ impl TripleAllocator {
         debug_assert!(dummy(self.current().object));
         let buffers = self.string_stack.push2();
         let object = object_factory(buffers.0, buffers.1)?;
-        debug_assert!(matches!(object, Term::NamedNode(_) | Term::BlankNode(_) | Term::Literal(_)));
+        debug_assert!(matches!(
+            object,
+            Term::NamedNode(_) | Term::BlankNode(_) | Term::Literal(_)
+        ));
         let object: Term<'static> = unsafe { transmute(object) };
         // The unsafe code above changes the lifetime parameter of object to `'static`.
         // This is ok because:

--- a/turtle/src/triple_allocator.rs
+++ b/turtle/src/triple_allocator.rs
@@ -1,0 +1,558 @@
+//! I define [`TripleAllocator`]
+
+#![allow(unsafe_code)]
+use crate::utils::StringBufferStack;
+use rio_api::model::*;
+use std::mem::transmute;
+
+/// A stack allocator for storing RDF and RDF* triples.
+///
+/// # Implementation
+/// This type uses `&'static str` internally to reference text that it allocates.
+/// It therefore contains unsafe code to cheat the borrow checker,
+/// but ensures that the referenced data lives as long as the referencing struct.
+pub struct TripleAllocator {
+    incomplete_stack: Vec<Triple<'static>>,
+    incomplete_len: usize,
+    #[allow(clippy::vec_box)]
+    complete_stack: Vec<Box<Triple<'static>>>,
+    complete_len: usize,
+    string_stack: StringBufferStack,
+}
+
+impl TripleAllocator {
+    pub fn new() -> TripleAllocator {
+        TripleAllocator {
+            incomplete_stack: Vec::with_capacity(1),
+            incomplete_len: 0,
+            complete_stack: Vec::with_capacity(1),
+            complete_len: 0,
+            string_stack: StringBufferStack::with_capacity(4),
+        }
+    }
+
+    pub fn top(&self) -> &Triple<'_> {
+        debug_assert!(self.complete_len > 0);
+        &self.complete_stack[self.complete_len - 1]
+    }
+
+    pub fn push_triple_start(&mut self) {
+        if self.incomplete_len == self.incomplete_stack.len() {
+            self.incomplete_stack.push(Triple {
+                subject: DUMMY_IRI.into(),
+                predicate: DUMMY_IRI,
+                object: DUMMY_IRI.into(),
+            })
+        }
+        #[cfg(debug_assertions)] // to ensure that dummy() assertions work
+        {
+            self.incomplete_stack[self.incomplete_len] = Triple {
+                subject: DUMMY_IRI.into(),
+                predicate: DUMMY_IRI,
+                object: DUMMY_IRI.into(),
+            }
+        }
+        self.incomplete_len += 1;
+    }
+
+    /// Push an atomic term, produced by `subject_factory`, as the subject of the current triple.
+    ///
+    /// # Pre-condition
+    /// In standard RDF, any subject is acceptable.
+    /// In RDF* (with the `star` feature),
+    /// embedded triples [`Subject::Triple`] are *not allowed*.
+    /// For adding an embedded triple, use [`TripleAllocator::push_subject_triple`] instead.
+    pub fn try_push_subject<E, F>(&mut self, subject_factory: F) -> Result<(), E>
+    where
+        F: FnOnce(&mut String) -> Result<Subject<'_>, E>,
+    {
+        debug_assert!(dummy(self.current().subject));
+        let buffer = self.string_stack.push();
+        let subject = subject_factory(buffer)?;
+        debug_assert!(matches!(subject, Subject::NamedNode(_) | Subject::BlankNode(_)));
+        let subject: Subject<'static> = unsafe { transmute(subject) };
+        // The unsafe code above changes the lifetime parameter of subject to `'static`.
+        // This is ok because:
+        // * we will only expose it with a shorter lifetime, and
+        // * this implementation guarantees that the pointed `str` lives as long as the subject
+        self.current().subject = subject;
+        Ok(())
+    }
+
+    /// Push an atomic term, produced by `predicate_factory`, as the predicate of the current triple.
+    pub fn try_push_predicate<E, F>(&mut self, predicate_factory: F) -> Result<(), E>
+    where
+        F: FnOnce(&mut String) -> Result<NamedNode<'_>, E>,
+    {
+        debug_assert!(dummy(self.current().predicate));
+        let buffer = self.string_stack.push();
+        let predicate = predicate_factory(buffer)?;
+        let predicate: NamedNode<'static> = unsafe { transmute(predicate) };
+        // The unsafe code above changes the lifetime parameter of predicate to `'static`.
+        // This is ok because:
+        // * we will only expose it with a shorter lifetime, and
+        // * this implementation guarantees that the pointed `str` lives as long as the predicate
+        self.current().predicate = predicate;
+        Ok(())
+    }
+
+    /// Push an atomic term, produced by `object_factory`, as the object of the current triple.
+    ///
+    /// # Pre-condition
+    /// In standard RDF, any object is acceptable.
+    /// In RDF* (with the `star` feature),
+    /// embedded triples [`Subject::Triple`] are *not allowed*.
+    /// For adding an embedded triple, use [`TripleAllocator::push_object_triple`] instead.
+    pub fn try_push_object<E, F>(&mut self, object_factory: F) -> Result<(), E>
+    where
+        F: for<'x> FnOnce(&'x mut String, &'x mut String) -> Result<Term<'x>, E>,
+    {
+        debug_assert!(dummy(self.current().object));
+        let buffers = self.string_stack.push2();
+        let object = object_factory(buffers.0, buffers.1)?;
+        debug_assert!(matches!(object, Term::NamedNode(_) | Term::BlankNode(_) | Term::Literal(_)));
+        let object: Term<'static> = unsafe { transmute(object) };
+        // The unsafe code above changes the lifetime parameter of object to `'static`.
+        // This is ok because:
+        // * we will only expose it with a shorter lifetime, and
+        // * this implementation guarantees that the pointed `str` lives as long as the object
+        self.complete_triple(object);
+        Ok(())
+    }
+
+    /// Use the [top](TripleAllocator::top) triple of this stash as the subject of the current triple.
+    #[cfg(feature = "star")]
+    pub fn push_subject_triple(&mut self) {
+        debug_assert!(dummy(self.current().subject));
+        debug_assert!(self.complete_len > 0);
+        let triple = &*self.complete_stack[self.complete_len - 1];
+        let triple: &'static Triple<'static> = unsafe { transmute(triple) };
+        // The unsafe code above changes the lifetime of the ref to `'static`.
+        // This is ok because:
+        // * we will only expose it with a shorter lifetime, and
+        // * this implementation guarantees that the pointed `Triple` lives as long as the `Term` embedding it
+        self.current().subject = Subject::Triple(triple);
+    }
+
+    /// Use the [top](TripleAllocator::top) triple of this stash as the object of the current triple.
+    ///
+    /// # Pre-condition
+    /// The top triple must not have been pushed already as the subject.
+    #[cfg(feature = "star")]
+    pub fn push_object_triple(&mut self) {
+        debug_assert!(dummy(self.current().object));
+        debug_assert!(self.complete_len > 0);
+        let triple = &*self.complete_stack[self.complete_len - 1];
+
+        #[cfg(debug_assertions)] // the subject triple, if any, must not be top()
+        debug_assert!(
+            match self.incomplete_stack[self.incomplete_len - 1].subject {
+                Subject::Triple(s) => {
+                    let ptr_s: *const _ = s;
+                    ptr_s != triple
+                }
+                _ => true,
+            }
+        );
+
+        let triple: &'static Triple<'static> = unsafe { transmute(triple) };
+        // The unsafe code above changes the lifetime of the ref to `'static`.
+        // This is ok because:
+        // * we will only expose it with a shorter lifetime, and
+        // * this implementation guarantees that the pointed `Triple` lives as long as the `Term` embedding it
+        self.complete_triple(Term::Triple(triple));
+    }
+
+    pub fn pop_object(&mut self) {
+        debug_assert!(self.complete_len > 0);
+        self.complete_len -= 1;
+        let inc_triple = *self.complete_stack[self.complete_len];
+        if self.incomplete_len == self.incomplete_stack.len() {
+            self.incomplete_stack.push(inc_triple)
+        } else {
+            self.incomplete_stack[self.incomplete_len] = inc_triple;
+        }
+        self.incomplete_len += 1;
+
+        match inc_triple.object {
+            Term::NamedNode(_) | Term::BlankNode(_) | Term::Literal(_) => {
+                // we allocate two buffers for any atomic object, even named or blank node
+                self.string_stack.pop();
+                self.string_stack.pop()
+            }
+            #[cfg(feature = "star")]
+            Term::Triple(_) => self.do_pop_top_triple(),
+            _ => (),
+        }
+        #[cfg(debug_assertions)] // to ensure that dummy() assertions work
+        {
+            self.current().object = DUMMY_IRI.into();
+        }
+    }
+
+    pub fn pop_predicate(&mut self) {
+        debug_assert!(dummy(self.current().object));
+        debug_assert!(!dummy(self.current().predicate));
+        self.string_stack.pop();
+        #[cfg(debug_assertions)] // to ensure that dummy() assertions work
+        {
+            self.current().predicate = DUMMY_IRI;
+        }
+    }
+
+    pub fn pop_subject(&mut self) {
+        debug_assert!(dummy(self.current().predicate));
+        debug_assert!(!dummy(self.current().subject));
+        match self.current().subject {
+            Subject::NamedNode(_) | Subject::BlankNode(_) => self.string_stack.pop(),
+            #[cfg(feature = "star")]
+            Subject::Triple(_) => self.do_pop_top_triple(),
+            _ => (),
+        }
+        #[cfg(debug_assertions)] // to ensure that dummy() assertions work
+        {
+            self.current().subject = DUMMY_IRI.into();
+        }
+    }
+
+    #[inline(always)]
+    pub fn pop_top_triple(&mut self) {
+        debug_assert_eq!(self.incomplete_len, 0);
+        self.do_pop_top_triple();
+    }
+
+    pub fn clear(&mut self) {
+        self.incomplete_len = 0;
+        self.incomplete_stack.clear();
+        self.complete_len = 0;
+        self.complete_stack.clear();
+        self.string_stack.clear();
+    }
+
+    fn complete_triple(&mut self, object: Term<'static>) {
+        self.incomplete_len -= 1;
+        let mut triple = self.incomplete_stack[self.incomplete_len];
+        triple.object = object;
+        if self.complete_len == self.complete_stack.len() {
+            self.complete_stack.push(Box::new(triple))
+        } else {
+            *self.complete_stack[self.complete_len] = triple;
+        }
+        self.complete_len += 1;
+    }
+
+    fn do_pop_top_triple(&mut self) {
+        debug_assert!(self.complete_len > 0);
+        self.pop_object();
+        self.pop_predicate();
+        self.pop_subject();
+        self.incomplete_len -= 1;
+    }
+
+    fn current(&mut self) -> &mut Triple<'static> {
+        debug_assert!(self.incomplete_len > 0);
+        &mut self.incomplete_stack[self.incomplete_len - 1]
+    }
+}
+
+#[cfg(debug_assertions)] // debug assertions need DUMMY to have a static address
+static DUMMY_IRI: NamedNode<'static> = NamedNode { iri: "" };
+#[cfg(not(debug_assertions))] // otherwise, a const is sufficient
+const DUMMY_IRI: NamedNode<'static> = NamedNode { iri: "" };
+
+fn dummy<'a, T: std::fmt::Debug + Into<Term<'a>>>(t: T) -> bool {
+    match t.into() {
+        Term::NamedNode(n) => {
+            let ptr_iri: *const str = n.iri;
+            ptr_iri == DUMMY_IRI.iri
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::convert::Infallible;
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn dummy_works() {
+        assert!(dummy(DUMMY_IRI));
+        let b = "foo".to_string();
+        let n = NamedNode { iri: &b[..0] };
+        assert!(DUMMY_IRI.iri == n.iri);
+        // and yet:
+        assert!(!dummy(n));
+    }
+
+    fn iri<'a, T: From<NamedNode<'a>>>(
+        buffer: &'a mut String,
+        value: &str,
+    ) -> Result<T, Infallible> {
+        buffer.push_str(value);
+        Ok(NamedNode { iri: &*buffer }.into())
+    }
+
+    fn bn<'a, T: From<BlankNode<'a>>>(
+        buffer: &'a mut String,
+        value: &str,
+    ) -> Result<T, Infallible> {
+        buffer.push_str(value);
+        Ok(BlankNode { id: &*buffer }.into())
+    }
+
+    fn sl<'a, T: From<Literal<'a>>>(buffer: &'a mut String, value: &str) -> Result<T, Infallible> {
+        buffer.push_str(value);
+        Ok(Literal::Simple { value: &*buffer }.into())
+    }
+
+    fn lt<'a, T: From<Literal<'a>>>(
+        buffer1: &'a mut String,
+        buffer2: &'a mut String,
+        value: &str,
+        tag: &str,
+    ) -> Result<T, Infallible> {
+        buffer1.push_str(value);
+        buffer2.push_str(tag);
+        Ok(Literal::LanguageTaggedString {
+            value: &*buffer1,
+            language: &*buffer2,
+        }
+        .into())
+    }
+
+    fn dt<'a, T: From<Literal<'a>>>(
+        buffer1: &'a mut String,
+        buffer2: &'a mut String,
+        value: &str,
+        dt: &str,
+    ) -> Result<T, Infallible> {
+        buffer1.push_str(value);
+        buffer2.push_str(dt);
+        Ok(Literal::Typed {
+            value: &*buffer1,
+            datatype: NamedNode { iri: &*buffer2 },
+        }
+        .into())
+    }
+
+    #[test]
+    fn simple_triple_w_named() -> Result<(), Infallible> {
+        let mut ta = TripleAllocator::new();
+        ta.push_triple_start();
+        ta.try_push_subject(|b| iri(b, "a").into())?;
+        ta.try_push_predicate(|b| iri(b, "b"))?;
+        ta.try_push_object(|b, _| iri(b, "c"))?;
+        assert_eq!(format!("{}", ta.top()), r#"<a> <b> <c> ."#);
+        Ok(())
+    }
+
+    #[test]
+    fn simple_triple_w_blank() -> Result<(), Infallible> {
+        let mut ta = TripleAllocator::new();
+        ta.push_triple_start();
+        ta.try_push_subject(|b| bn(b, "a"))?;
+        ta.try_push_predicate(|b| iri(b, "b"))?;
+        ta.try_push_object(|b, _| bn(b, "c"))?;
+        assert_eq!(format!("{}", ta.top()), r#"_:a <b> _:c ."#);
+        Ok(())
+    }
+
+    #[test]
+    fn simple_triple_w_simple_lit() -> Result<(), Infallible> {
+        let mut ta = TripleAllocator::new();
+        ta.push_triple_start();
+        ta.try_push_subject(|b| bn(b, "a"))?;
+        ta.try_push_predicate(|b| iri(b, "b"))?;
+        ta.try_push_object(|b, _| sl(b, "c"))?;
+        assert_eq!(format!("{}", ta.top()), r#"_:a <b> "c" ."#);
+        Ok(())
+    }
+
+    #[test]
+    fn simple_triple_w_lang_lit() -> Result<(), Infallible> {
+        let mut ta = TripleAllocator::new();
+        ta.push_triple_start();
+        ta.try_push_subject(|b| bn(b, "a"))?;
+        ta.try_push_predicate(|b| iri(b, "b"))?;
+        ta.try_push_object(|b1, b2| lt(b1, b2, "c", "en"))?;
+        assert_eq!(format!("{}", ta.top()), r#"_:a <b> "c"@en ."#);
+        Ok(())
+    }
+
+    #[test]
+    fn simple_triple_w_typed_lit() -> Result<(), Infallible> {
+        let mut ta = TripleAllocator::new();
+        ta.push_triple_start();
+        ta.try_push_subject(|b| bn(b, "a"))?;
+        ta.try_push_predicate(|b| iri(b, "b"))?;
+        ta.try_push_object(|b1, b2| dt(b1, b2, "c", "d"))?;
+        assert_eq!(format!("{}", ta.top()), r#"_:a <b> "c"^^<d> ."#);
+        Ok(())
+    }
+
+    #[test]
+    fn simple_triples_pop() -> Result<(), Infallible> {
+        let mut ta = TripleAllocator::new();
+        ta.push_triple_start();
+        ta.try_push_subject(|b| iri(b, "a"))?;
+        ta.try_push_predicate(|b| iri(b, "b"))?;
+        ta.try_push_object(|b, _| iri(b, "c"))?;
+        assert_eq!(format!("{}", ta.top()), r#"<a> <b> <c> ."#);
+        ta.pop_object();
+        ta.try_push_object(|b, _| iri(b, "d"))?;
+        assert_eq!(format!("{}", ta.top()), r#"<a> <b> <d> ."#);
+        ta.pop_object();
+        ta.pop_predicate();
+        ta.try_push_predicate(|b| iri(b, "e"))?;
+        ta.try_push_object(|b, _| iri(b, "f"))?;
+        assert_eq!(format!("{}", ta.top()), r#"<a> <e> <f> ."#);
+        ta.pop_object();
+        ta.try_push_object(|b, _| iri(b, "g"))?;
+        assert_eq!(format!("{}", ta.top()), r#"<a> <e> <g> ."#);
+        ta.pop_object();
+        ta.pop_predicate();
+        ta.pop_subject();
+        ta.try_push_subject(|b| iri(b, "h"))?;
+        ta.try_push_predicate(|b| iri(b, "i"))?;
+        ta.try_push_object(|b, _| iri(b, "j"))?;
+        assert_eq!(format!("{}", ta.top()), r#"<h> <i> <j> ."#);
+        Ok(())
+    }
+
+    #[test]
+    fn simple_triples_stacked() -> Result<(), Infallible> {
+        let mut ta = TripleAllocator::new();
+        ta.push_triple_start();
+        ta.try_push_subject(|b| iri(b, "a"))?;
+        ta.try_push_predicate(|b| iri(b, "b"))?;
+        ta.try_push_object(|b, _| iri(b, "c"))?;
+        assert_eq!(format!("{}", ta.top()), r#"<a> <b> <c> ."#);
+        ta.push_triple_start();
+        ta.try_push_subject(|b| iri(b, "d"))?;
+        ta.try_push_predicate(|b| iri(b, "e"))?;
+        ta.try_push_object(|b, _| iri(b, "f"))?;
+        assert_eq!(format!("{}", ta.top()), r#"<d> <e> <f> ."#);
+        ta.pop_top_triple();
+        assert_eq!(format!("{}", ta.top()), r#"<a> <b> <c> ."#);
+        ta.pop_top_triple();
+        assert_eq!(ta.complete_len, 0);
+        assert_eq!(ta.incomplete_len, 0);
+        Ok(())
+    }
+
+    #[cfg(feature = "star")]
+    #[test]
+    fn nested_triple_as_subject() -> Result<(), Infallible> {
+        let mut ta = TripleAllocator::new();
+        ta.push_triple_start();
+        {
+            ta.push_triple_start();
+            ta.try_push_subject(|b| bn(b, "a"))?;
+            ta.try_push_predicate(|b| iri(b, "b"))?;
+            ta.try_push_object(|b, _| sl(b, "c"))?;
+            assert_eq!(format!("{}", ta.top()), r#"_:a <b> "c" ."#);
+        }
+        ta.push_subject_triple();
+        ta.try_push_predicate(|b| iri(b, "d"))?;
+        ta.try_push_object(|b, _| sl(b, "e"))?;
+        assert_eq!(format!("{}", ta.top()), r#"<< _:a <b> "c" >> <d> "e" ."#);
+        Ok(())
+    }
+
+    #[cfg(feature = "star")]
+    #[test]
+    fn nested_triple_as_object() -> Result<(), Infallible> {
+        let mut ta = TripleAllocator::new();
+        ta.push_triple_start();
+        ta.try_push_subject(|b| bn(b, "a"))?;
+        ta.try_push_predicate(|b| iri(b, "b"))?;
+        {
+            ta.push_triple_start();
+            ta.try_push_subject(|b| bn(b, "c"))?;
+            ta.try_push_predicate(|b| iri(b, "d"))?;
+            ta.try_push_object(|b, _| sl(b, "e"))?;
+            assert_eq!(format!("{}", ta.top()), r#"_:c <d> "e" ."#);
+        }
+        ta.push_object_triple();
+        assert_eq!(format!("{}", ta.top()), r#"_:a <b> << _:c <d> "e" >> ."#);
+        Ok(())
+    }
+
+    #[cfg(feature = "star")]
+    #[test]
+    fn nested_triple_as_both() -> Result<(), Infallible> {
+        let mut ta = TripleAllocator::new();
+        ta.push_triple_start();
+        {
+            ta.push_triple_start();
+            ta.try_push_subject(|b| bn(b, "a"))?;
+            ta.try_push_predicate(|b| iri(b, "b"))?;
+            ta.try_push_object(|b, _| sl(b, "c"))?;
+            assert_eq!(format!("{}", ta.top()), r#"_:a <b> "c" ."#);
+        }
+        ta.push_subject_triple();
+        ta.try_push_predicate(|b| iri(b, "d"))?;
+        {
+            ta.push_triple_start();
+            ta.try_push_subject(|b| bn(b, "e"))?;
+            ta.try_push_predicate(|b| iri(b, "f"))?;
+            ta.try_push_object(|b, _| sl(b, "g"))?;
+            assert_eq!(format!("{}", ta.top()), r#"_:e <f> "g" ."#);
+        }
+        ta.push_object_triple();
+        assert_eq!(
+            format!("{}", ta.top()),
+            r#"<< _:a <b> "c" >> <d> << _:e <f> "g" >> ."#
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "star")]
+    #[test]
+    fn nested_triple_deep() -> Result<(), Infallible> {
+        let mut ta = TripleAllocator::new();
+        ta.push_triple_start();
+        {
+            ta.push_triple_start();
+            ta.try_push_subject(|b| bn(b, "a"))?;
+            ta.try_push_predicate(|b| iri(b, "b"))?;
+            {
+                ta.push_triple_start();
+                ta.try_push_subject(|b| bn(b, "c"))?;
+                ta.try_push_predicate(|b| iri(b, "d"))?;
+                ta.try_push_object(|b, _| sl(b, "e"))?;
+                assert_eq!(format!("{}", ta.top()), r#"_:c <d> "e" ."#);
+            }
+            ta.push_object_triple();
+            assert_eq!(format!("{}", ta.top()), r#"_:a <b> << _:c <d> "e" >> ."#);
+        }
+        ta.push_subject_triple();
+        ta.try_push_predicate(|b| iri(b, "f"))?;
+        {
+            ta.push_triple_start();
+            {
+                ta.push_triple_start();
+                ta.try_push_subject(|b| bn(b, "g"))?;
+                ta.try_push_predicate(|b| iri(b, "h"))?;
+                ta.try_push_object(|b, _| sl(b, "i"))?;
+                assert_eq!(format!("{}", ta.top()), r#"_:g <h> "i" ."#);
+            }
+            ta.push_subject_triple();
+            ta.try_push_predicate(|b| iri(b, "j"))?;
+            ta.try_push_object(|b, _| sl(b, "k"))?;
+            assert_eq!(format!("{}", ta.top()), r#"<< _:g <h> "i" >> <j> "k" ."#);
+        }
+        ta.push_object_triple();
+        assert_eq!(
+            format!("{}", ta.top()),
+            r#"<< _:a <b> << _:c <d> "e" >> >> <f> << << _:g <h> "i" >> <j> "k" >> ."#
+        );
+
+        ta.pop_top_triple();
+        assert_eq!(ta.complete_len, 0);
+        assert_eq!(ta.incomplete_len, 0);
+        Ok(())
+    }
+}

--- a/turtle/src/utils.rs
+++ b/turtle/src/utils.rs
@@ -64,6 +64,14 @@ pub trait LookAheadByteRead {
         }
     }
 
+    fn check_is_next(&mut self, expected: u8) -> Result<(), TurtleError> {
+        if self.next()? == Some(expected) {
+            Ok(())
+        } else {
+            self.unexpected_char_error()
+        }
+    }
+
     fn parse_error(&self, kind: TurtleErrorKind) -> TurtleError {
         TurtleError {
             kind,

--- a/turtle/src/utils.rs
+++ b/turtle/src/utils.rs
@@ -242,14 +242,6 @@ impl StringBufferStack {
         self.len -= 1;
     }
 
-    pub fn last(&self) -> &str {
-        &self.inner[self.len - 1]
-    }
-
-    pub fn before_last(&self) -> &str {
-        &self.inner[self.len - 2]
-    }
-
     pub fn clear(&mut self) {
         self.inner.clear();
         self.len = 0;

--- a/xml/src/model.rs
+++ b/xml/src/model.rs
@@ -92,38 +92,42 @@ impl<'a> From<&'a OwnedLiteral> for Literal<'a> {
 }
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Hash)]
-pub enum OwnedNamedOrBlankNode {
+pub enum OwnedSubject {
     NamedNode(OwnedNamedNode),
     BlankNode(OwnedBlankNode),
 }
 
-impl From<NamedOrBlankNode<'_>> for OwnedNamedOrBlankNode {
-    fn from(t: NamedOrBlankNode<'_>) -> Self {
+impl std::convert::TryFrom<Subject<'_>> for OwnedSubject {
+    type Error = crate::RdfXmlError;
+    fn try_from(t: Subject<'_>) -> Result<Self, Self::Error> {
         match t {
-            NamedOrBlankNode::NamedNode(n) => OwnedNamedOrBlankNode::NamedNode(n.into()),
-            NamedOrBlankNode::BlankNode(n) => OwnedNamedOrBlankNode::BlankNode(n.into()),
+            Subject::NamedNode(n) => Ok(OwnedSubject::NamedNode(n.into())),
+            Subject::BlankNode(n) => Ok(OwnedSubject::BlankNode(n.into())),
+            _ => Err(crate::RdfXmlError::msg(
+                "RDF/XML only supports named or blank subject",
+            )),
         }
     }
 }
 
-impl<'a> From<&'a OwnedNamedOrBlankNode> for NamedOrBlankNode<'a> {
-    fn from(t: &'a OwnedNamedOrBlankNode) -> Self {
+impl<'a> From<&'a OwnedSubject> for Subject<'a> {
+    fn from(t: &'a OwnedSubject) -> Self {
         match t {
-            OwnedNamedOrBlankNode::NamedNode(n) => NamedOrBlankNode::NamedNode(n.into()),
-            OwnedNamedOrBlankNode::BlankNode(n) => NamedOrBlankNode::BlankNode(n.into()),
+            OwnedSubject::NamedNode(n) => Subject::NamedNode(n.into()),
+            OwnedSubject::BlankNode(n) => Subject::BlankNode(n.into()),
         }
     }
 }
 
-impl From<OwnedNamedNode> for OwnedNamedOrBlankNode {
+impl From<OwnedNamedNode> for OwnedSubject {
     fn from(node: OwnedNamedNode) -> Self {
-        OwnedNamedOrBlankNode::NamedNode(node)
+        OwnedSubject::NamedNode(node)
     }
 }
 
-impl From<OwnedBlankNode> for OwnedNamedOrBlankNode {
+impl From<OwnedBlankNode> for OwnedSubject {
     fn from(node: OwnedBlankNode) -> Self {
-        OwnedNamedOrBlankNode::BlankNode(node)
+        OwnedSubject::BlankNode(node)
     }
 }
 
@@ -162,11 +166,11 @@ impl From<OwnedLiteral> for OwnedTerm {
     }
 }
 
-impl From<OwnedNamedOrBlankNode> for OwnedTerm {
-    fn from(resource: OwnedNamedOrBlankNode) -> Self {
+impl From<OwnedSubject> for OwnedTerm {
+    fn from(resource: OwnedSubject) -> Self {
         match resource {
-            OwnedNamedOrBlankNode::NamedNode(node) => OwnedTerm::NamedNode(node),
-            OwnedNamedOrBlankNode::BlankNode(node) => OwnedTerm::BlankNode(node),
+            OwnedSubject::NamedNode(node) => OwnedTerm::NamedNode(node),
+            OwnedSubject::BlankNode(node) => OwnedTerm::BlankNode(node),
         }
     }
 }

--- a/xml/src/parser.rs
+++ b/xml/src/parser.rs
@@ -767,10 +767,6 @@ impl<R: BufRead> RdfXmlReader<R> {
                 object: NamedNode::from(&iri).into(),
             })?;
         }
-        #[cfg(feature = "rio_common/star")]
-        if let Subject::Triple(_) = &subject {
-            return Err(RdfXmlError::msg("RDF/XML does not support RDF*").into());
-        }
         Ok(RdfXmlState::NodeElt {
             base_iri,
             language,


### PR DESCRIPTION
in rio_api
- rename NamedOrBlankNode to GraphName
- add type Subject, which is NamedOrBlankNode + Triple (if 'star' enabled)
- Subject and Term are marked as non_exhaustive enums;
  this is a breaking change, but allows non-star crates (e.g. rio_xml)
  to co-exist with star crates

in other crates:
- propagate the changes above
- in particular, because Subject and Term are now non-exhaustive enums,
  some From implementations have been replaced with TryFrom;
  this should be zero-cost when all existing variants are actually
  handled.

NB: a consequence of adding the Triple variant is that
owned versions of Terms can no longer be converted into the borrowed versions
(or at least not easily).
It appears that such conversions were not really needed
(for example, they were used to compare owned terms with borrowed terms,
which is now achieved by implementing PartialEq instead).