### PR TITLE
Makes rdf-star enabled by default and drops non_exhaustive

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -16,7 +16,6 @@ all-features = true
 
 [features]
 default = []
-star = []
 generalized = []
 sophia = ["sophia_api"]
 

--- a/api/src/generalized.rs
+++ b/api/src/generalized.rs
@@ -51,7 +51,6 @@ pub mod model {
     ///
     /// Using it requires to enable the `generalized` feature.
     #[derive(Eq, PartialEq, Debug, Clone, Copy, Hash)]
-    #[non_exhaustive]
     pub enum GeneralizedTerm<'a> {
         NamedNode(NamedNode<'a>),
         BlankNode(BlankNode<'a>),

--- a/api/src/generalized.rs
+++ b/api/src/generalized.rs
@@ -57,7 +57,6 @@ pub mod model {
         BlankNode(BlankNode<'a>),
         Literal(Literal<'a>),
         Variable(Variable<'a>),
-        #[cfg(feature = "star")]
         Triple(&'a Triple<'a>),
     }
 
@@ -95,7 +94,6 @@ pub mod model {
             match other {
                 Subject::NamedNode(inner) => GeneralizedTerm::NamedNode(inner),
                 Subject::BlankNode(inner) => GeneralizedTerm::BlankNode(inner),
-                #[cfg(feature = "star")]
                 Subject::Triple(inner) => GeneralizedTerm::Triple(inner),
             }
         }
@@ -118,7 +116,6 @@ pub mod model {
                 Term::NamedNode(inner) => GeneralizedTerm::NamedNode(inner),
                 Term::BlankNode(inner) => GeneralizedTerm::BlankNode(inner),
                 Term::Literal(inner) => GeneralizedTerm::Literal(inner),
-                #[cfg(feature = "star")]
                 Term::Triple(inner) => GeneralizedTerm::Triple(inner),
             }
         }
@@ -140,7 +137,6 @@ pub mod model {
                 GeneralizedTerm::Variable(_) => Err(StrictRdfError {
                     message: "Variable cannot be converted to Term",
                 }),
-                #[cfg(feature = "star")]
                 GeneralizedTerm::Triple(_) => Err(StrictRdfError {
                     message: "Triple cannot be used as predicate",
                 }),
@@ -162,7 +158,6 @@ pub mod model {
                 GeneralizedTerm::Variable(_) => Err(StrictRdfError {
                     message: "Variable cannot be converted to Term",
                 }),
-                #[cfg(feature = "star")]
                 GeneralizedTerm::Triple(triple) => Ok(Subject::Triple(triple)),
             }
         }
@@ -182,7 +177,6 @@ pub mod model {
                 GeneralizedTerm::Variable(_) => Err(StrictRdfError {
                     message: "Variable cannot be converted to Term",
                 }),
-                #[cfg(feature = "star")]
                 GeneralizedTerm::Triple(_) => Err(StrictRdfError {
                     message: "Triple cannot be used as a graph name",
                 }),
@@ -202,7 +196,6 @@ pub mod model {
                 GeneralizedTerm::Variable(_) => Err(StrictRdfError {
                     message: "Variable cannot be converted to Term",
                 }),
-                #[cfg(feature = "star")]
                 GeneralizedTerm::Triple(inner) => Ok(Term::Triple(inner)),
             }
         }
@@ -216,7 +209,6 @@ pub mod model {
                 GeneralizedTerm::BlankNode(node) => node.fmt(f),
                 GeneralizedTerm::Literal(literal) => literal.fmt(f),
                 GeneralizedTerm::Variable(variable) => variable.fmt(f),
-                #[cfg(feature = "star")]
                 GeneralizedTerm::Triple(triple) => triple.fmt(f),
             }
         }

--- a/api/src/model.rs
+++ b/api/src/model.rs
@@ -130,7 +130,6 @@ impl<'a> fmt::Display for Literal<'a> {
 pub enum Subject<'a> {
     NamedNode(NamedNode<'a>),
     BlankNode(BlankNode<'a>),
-    #[cfg(feature = "star")]
     Triple(&'a Triple<'a>),
 }
 
@@ -140,7 +139,6 @@ impl<'a> fmt::Display for Subject<'a> {
         match self {
             Subject::NamedNode(node) => node.fmt(f),
             Subject::BlankNode(node) => node.fmt(f),
-            #[cfg(feature = "star")]
             Subject::Triple(triple) => write!(
                 f,
                 "<< {} {} {} >>",
@@ -164,7 +162,6 @@ impl<'a> From<BlankNode<'a>> for Subject<'a> {
     }
 }
 
-#[cfg(feature = "star")]
 impl<'a> From<&'a Triple<'a>> for Subject<'a> {
     #[inline]
     fn from(triple: &'a Triple<'a>) -> Self {
@@ -193,7 +190,6 @@ pub enum Term<'a> {
     NamedNode(NamedNode<'a>),
     BlankNode(BlankNode<'a>),
     Literal(Literal<'a>),
-    #[cfg(feature = "star")]
     Triple(&'a Triple<'a>),
 }
 
@@ -204,7 +200,6 @@ impl<'a> fmt::Display for Term<'a> {
             Term::NamedNode(node) => node.fmt(f),
             Term::BlankNode(node) => node.fmt(f),
             Term::Literal(literal) => literal.fmt(f),
-            #[cfg(feature = "star")]
             Term::Triple(triple) => write!(
                 f,
                 "<< {} {} {} >>",
@@ -241,7 +236,6 @@ impl<'a> From<Subject<'a>> for Term<'a> {
         match resource {
             Subject::NamedNode(node) => Term::NamedNode(node),
             Subject::BlankNode(node) => Term::BlankNode(node),
-            #[cfg(feature = "star")]
             Subject::Triple(triple) => Term::Triple(triple),
         }
     }

--- a/api/src/model.rs
+++ b/api/src/model.rs
@@ -126,7 +126,6 @@ impl<'a> fmt::Display for Literal<'a> {
 ///
 /// The default string formatter is returning an N-Triples, Turtle and SPARQL compatible representation.
 #[derive(Eq, PartialEq, Debug, Clone, Copy, Hash)]
-#[non_exhaustive]
 pub enum Subject<'a> {
     NamedNode(NamedNode<'a>),
     BlankNode(BlankNode<'a>),
@@ -185,7 +184,6 @@ impl<'a> From<GraphName<'a>> for Subject<'a> {
 ///
 /// The default string formatter is returning an N-Triples, Turtle and SPARQL compatible representation.
 #[derive(Eq, PartialEq, Debug, Clone, Copy, Hash)]
-#[non_exhaustive]
 pub enum Term<'a> {
     NamedNode(NamedNode<'a>),
     BlankNode(BlankNode<'a>),

--- a/api/src/sophia.rs
+++ b/api/src/sophia.rs
@@ -92,7 +92,6 @@ impl<'a> TTerm for Subject<'a> {
         match self {
             Subject::NamedNode(_) => TermKind::Iri,
             Subject::BlankNode(_) => TermKind::BlankNode,
-            #[cfg(feature = "star")]
             Subject::Triple(_) => panic!("Sophia does not support RDF* yet"),
         }
     }
@@ -102,7 +101,6 @@ impl<'a> TTerm for Subject<'a> {
         match self {
             Subject::NamedNode(n) => n.value_raw(),
             Subject::BlankNode(n) => n.value_raw(),
-            #[cfg(feature = "star")]
             Subject::Triple(_) => panic!("Sophia does not support RDF* yet"),
         }
     }
@@ -143,7 +141,6 @@ impl<'a> TTerm for Term<'a> {
             Term::NamedNode(_) => TermKind::Iri,
             Term::BlankNode(_) => TermKind::BlankNode,
             Term::Literal(_) => TermKind::Literal,
-            #[cfg(feature = "star")]
             Term::Triple(_) => panic!("Sophia does not support RDF* yet"),
         }
     }
@@ -154,7 +151,6 @@ impl<'a> TTerm for Term<'a> {
             Term::NamedNode(n) => n.value_raw(),
             Term::BlankNode(n) => n.value_raw(),
             Term::Literal(l) => l.value_raw(),
-            #[cfg(feature = "star")]
             Term::Triple(_) => panic!("Sophia does not support RDF* yet"),
         }
     }
@@ -208,7 +204,6 @@ impl<'a> TTerm for GeneralizedTerm<'a> {
             GeneralizedTerm::BlankNode(_) => TermKind::BlankNode,
             GeneralizedTerm::Literal(_) => TermKind::Literal,
             GeneralizedTerm::Variable(_) => TermKind::Variable,
-            #[cfg(feature = "star")]
             GeneralizedTerm::Triple(_) => panic!("Sophia does not support RDF* yet"),
         }
     }
@@ -220,7 +215,6 @@ impl<'a> TTerm for GeneralizedTerm<'a> {
             GeneralizedTerm::BlankNode(n) => n.value_raw(),
             GeneralizedTerm::Literal(l) => l.value_raw(),
             GeneralizedTerm::Variable(v) => v.value_raw(),
-            #[cfg(feature = "star")]
             GeneralizedTerm::Triple(_) => panic!("Sophia does not support RDF* yet"),
         }
     }

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 publish = false
 
 [dependencies]
-rio_api = { version = "0.5", path="../api", features=["star"] }
-rio_turtle = { version = "0.5", path="../turtle", features=["star"] }
+rio_api = { version = "0.5", path="../api" }
+rio_turtle = { version = "0.5", path="../turtle" }
 rio_xml = { version = "0.5", path="../xml" }
 chrono = "0.4"
 oxiri = "0.1"

--- a/testsuite/src/model.rs
+++ b/testsuite/src/model.rs
@@ -170,7 +170,6 @@ impl From<Subject<'_>> for OwnedSubject {
             Subject::NamedNode(n) => OwnedSubject::NamedNode(n.into()),
             Subject::BlankNode(n) => OwnedSubject::BlankNode(n.into()),
             Subject::Triple(t) => OwnedSubject::Triple(Box::new(OwnedTriple::from(*t))),
-            _ => panic!("Unsupported subject {:?}", t),
         }
     }
 }
@@ -284,7 +283,6 @@ impl From<Term<'_>> for OwnedTerm {
             Term::BlankNode(n) => OwnedTerm::BlankNode(n.into()),
             Term::Literal(n) => OwnedTerm::Literal(n.into()),
             Term::Triple(t) => OwnedTerm::Triple(Box::new(OwnedTriple::from(*t))),
-            _ => panic!("Unsupported subject {:?}", t),
         }
     }
 }

--- a/turtle/Cargo.toml
+++ b/turtle/Cargo.toml
@@ -18,7 +18,6 @@ all-features = true
 default = []
 generalized = ["rio_api/generalized"]
 sophia = ["rio_api/sophia", "sophia_api"]
-star = ["rio_api/star"]
 
 [dependencies]
 oxilangtag = "0.1"

--- a/turtle/src/formatters.rs
+++ b/turtle/src/formatters.rs
@@ -173,7 +173,6 @@ impl<W: Write> TriplesFormatter for TurtleFormatter<W> {
                 self.current_subject.push_str(n.id);
                 self.current_subject_type = Some(SubjectType::BlankNode);
             }
-            #[cfg(feature = "star")]
             Subject::Triple(_) => {
                 // can't factorize embedded triple as subject for the moment
                 self.current_subject_type = None;
@@ -327,7 +326,6 @@ impl<W: Write> QuadsFormatter for TriGFormatter<W> {
                 self.current_subject.push_str(n.id);
                 self.current_subject_type = Some(SubjectType::BlankNode);
             }
-            #[cfg(feature = "star")]
             Subject::Triple(_) => {
                 // can't factorize embedded triple as subject for the moment
                 self.current_subject_type = None;

--- a/turtle/src/formatters.rs
+++ b/turtle/src/formatters.rs
@@ -177,7 +177,6 @@ impl<W: Write> TriplesFormatter for TurtleFormatter<W> {
                 // can't factorize embedded triple as subject for the moment
                 self.current_subject_type = None;
             }
-            _ => return Err(io::Error::from(io::ErrorKind::InvalidData)),
         }
         self.current_predicate.clear();
         self.current_predicate.push_str(triple.predicate.iri);
@@ -330,7 +329,6 @@ impl<W: Write> QuadsFormatter for TriGFormatter<W> {
                 // can't factorize embedded triple as subject for the moment
                 self.current_subject_type = None;
             }
-            _ => return Err(io::Error::from(io::ErrorKind::InvalidData)),
         }
         self.current_predicate.clear();
         self.current_predicate.push_str(quad.predicate.iri);

--- a/turtle/src/ntriples.rs
+++ b/turtle/src/ntriples.rs
@@ -204,19 +204,13 @@ fn parse_triple(
 ) -> Result<(), TurtleError> {
     triple_alloc.push_triple_start();
 
-    #[cfg(not(feature = "star"))]
-    triple_alloc.try_push_subject(|b| parse_subject(read, b))?;
-    #[cfg(feature = "star")]
-    parse_subject_star(read, triple_alloc)?;
+    parse_subject(read, triple_alloc)?;
     skip_whitespace(read)?;
 
     triple_alloc.try_push_predicate(|b| parse_iriref(read, b))?;
     skip_whitespace(read)?;
 
-    #[cfg(not(feature = "star"))]
-    triple_alloc.try_push_object(|b1, b2| parse_term(read, b1, b2))?;
-    #[cfg(feature = "star")]
-    parse_object_star(read, triple_alloc)?;
+    parse_object(read, triple_alloc)?;
     skip_whitespace(read)?;
 
     Ok(())
@@ -259,34 +253,7 @@ fn parse_quad_line<'a>(
     Ok(Some(opt_graph_name))
 }
 
-#[cfg(not(feature = "star"))]
-fn parse_term<'a>(
-    read: &mut impl LookAheadByteRead,
-    buffer: &'a mut String,
-    annotation_buffer: &'a mut String,
-) -> Result<Term<'a>, TurtleError> {
-    match read.required_current()? {
-        b'<' => Ok(parse_iriref(read, buffer)?.into()),
-        b'_' => Ok(parse_blank_node_label(read, buffer)?.into()),
-        b'"' => Ok(parse_literal(read, buffer, annotation_buffer)?.into()),
-        _ => read.unexpected_char_error(),
-    }
-}
-
-#[cfg(not(feature = "star"))]
-fn parse_subject<'a>(
-    read: &mut impl LookAheadByteRead,
-    buffer: &'a mut String,
-) -> Result<Subject<'a>, TurtleError> {
-    match read.required_current()? {
-        b'<' => Ok(parse_iriref(read, buffer)?.into()),
-        b'_' => Ok(parse_blank_node_label(read, buffer)?.into()),
-        _ => read.unexpected_char_error(),
-    }
-}
-
-#[cfg(feature = "star")]
-fn parse_subject_star(
+fn parse_subject(
     read: &mut impl LookAheadByteRead,
     triple_alloc: &mut TripleAllocator,
 ) -> Result<(), TurtleError> {
@@ -306,8 +273,7 @@ fn parse_subject_star(
     }
 }
 
-#[cfg(feature = "star")]
-fn parse_object_star(
+fn parse_object(
     read: &mut impl LookAheadByteRead,
     triple_alloc: &mut TripleAllocator,
 ) -> Result<(), TurtleError> {
@@ -328,7 +294,6 @@ fn parse_object_star(
     }
 }
 
-#[cfg(feature = "star")]
 fn parse_embedded_triple(
     read: &mut impl LookAheadByteRead,
     triple_alloc: &mut TripleAllocator,
@@ -422,7 +387,6 @@ fn parse_iriref<'a>(
 
 #[cfg(test)]
 mod test {
-    #[cfg(feature = "star")]
     #[test]
     fn nquads_star_valid_quad() -> Result<(), Box<dyn std::error::Error>> {
         // adding this test because there is currenly no testsuite specific to N-Quads star
@@ -438,7 +402,6 @@ mod test {
         Ok(())
     }
 
-    #[cfg(feature = "star")]
     #[test]
     fn nquads_star_invalid_graph_name() {
         // adding this test because there is currenly no testsuite specific to N-Quads star

--- a/turtle/src/triple_allocator.rs
+++ b/turtle/src/triple_allocator.rs
@@ -201,7 +201,6 @@ impl TripleAllocator {
                 self.string_stack.pop()
             }
             Term::Triple(_) => self.pop_top_triple(),
-            _ => (),
         }
         #[cfg(debug_assertions)] // to ensure that dummy() assertions work
         {
@@ -225,7 +224,6 @@ impl TripleAllocator {
         match self.current().subject {
             Subject::NamedNode(_) | Subject::BlankNode(_) => self.string_stack.pop(),
             Subject::Triple(_) => self.pop_top_triple(),
-            _ => (),
         }
         #[cfg(debug_assertions)] // to ensure that dummy() assertions work
         {

--- a/turtle/src/triple_allocator.rs
+++ b/turtle/src/triple_allocator.rs
@@ -74,8 +74,7 @@ impl TripleAllocator {
     ///
     /// # Pre-condition
     /// In standard RDF, any subject is acceptable.
-    /// In RDF* (with the `star` feature),
-    /// embedded triples [`Subject::Triple`] are *not allowed*.
+    /// In RDF* embedded triples [`Subject::Triple`] are *not allowed*.
     /// For adding an embedded triple, use [`TripleAllocator::push_subject_triple`] instead.
     pub fn try_push_subject<E, F>(&mut self, subject_factory: F) -> Result<(), E>
     where
@@ -119,8 +118,7 @@ impl TripleAllocator {
     ///
     /// # Pre-condition
     /// In standard RDF, any object is acceptable.
-    /// In RDF* (with the `star` feature),
-    /// embedded triples [`Subject::Triple`] are *not allowed*.
+    /// In RDF* embedded triples [`Subject::Triple`] are *not allowed*.
     /// For adding an embedded triple, use [`TripleAllocator::push_object_triple`] instead.
     pub fn try_push_object<E, F>(&mut self, object_factory: F) -> Result<(), E>
     where
@@ -144,7 +142,6 @@ impl TripleAllocator {
     }
 
     /// Use the [top](TripleAllocator::top) triple of this stash as the subject of the current triple.
-    #[cfg(feature = "star")]
     pub fn push_subject_triple(&mut self) {
         debug_assert!(dummy(self.current().subject));
         debug_assert!(self.complete_len > 0);
@@ -161,7 +158,6 @@ impl TripleAllocator {
     ///
     /// # Pre-condition
     /// The top triple must not have been pushed already as the subject.
-    #[cfg(feature = "star")]
     pub fn push_object_triple(&mut self) {
         debug_assert!(!dummy(self.current().predicate));
         debug_assert!(dummy(self.current().object));
@@ -204,7 +200,6 @@ impl TripleAllocator {
                 self.string_stack.pop();
                 self.string_stack.pop()
             }
-            #[cfg(feature = "star")]
             Term::Triple(_) => self.pop_top_triple(),
             _ => (),
         }
@@ -229,7 +224,6 @@ impl TripleAllocator {
         debug_assert!(!dummy(self.current().subject));
         match self.current().subject {
             Subject::NamedNode(_) | Subject::BlankNode(_) => self.string_stack.pop(),
-            #[cfg(feature = "star")]
             Subject::Triple(_) => self.pop_top_triple(),
             _ => (),
         }
@@ -264,7 +258,6 @@ impl TripleAllocator {
     /// and that subject is an embedded triple.
     ///
     /// The goal is to remove this triple *without* freeing the subject triple.
-    #[cfg(feature = "star")]
     #[inline(always)]
     pub fn pop_annotation_triple(&mut self) {
         debug_assert!(self.incomplete_len > 0);
@@ -487,7 +480,6 @@ mod test {
         Ok(())
     }
 
-    #[cfg(feature = "star")]
     #[test]
     fn nested_triple_as_subject() -> Result<(), Infallible> {
         let mut ta = TripleAllocator::new();
@@ -506,7 +498,6 @@ mod test {
         Ok(())
     }
 
-    #[cfg(feature = "star")]
     #[test]
     fn nested_triple_as_object() -> Result<(), Infallible> {
         let mut ta = TripleAllocator::new();
@@ -525,7 +516,6 @@ mod test {
         Ok(())
     }
 
-    #[cfg(feature = "star")]
     #[test]
     fn nested_triple_as_both() -> Result<(), Infallible> {
         let mut ta = TripleAllocator::new();
@@ -554,7 +544,6 @@ mod test {
         Ok(())
     }
 
-    #[cfg(feature = "star")]
     #[test]
     fn nested_triple_deep() -> Result<(), Infallible> {
         let mut ta = TripleAllocator::new();


### PR DESCRIPTION
It significantly simplifies usages of Rio imho:
* If the end user want to support rdf-star, they just need to take care of all terms like usual in Rust.
* If the end user does not want to support rdf-star, they have to fail on nested triples, just like they would have to fail if the term structs where`#[non_exhaustive]`.

So, this seems to me a better compromise than the previous state "rdf-star optional + #[non_exhaustive].

Adding a new term type would be very likely to be a breaking change anyway and having exhaustive structs makes refactoring of downstream code much safer when a new term type is introduced thanks to the absence of error prone catch-all options.

@pchampin What do you think about it?