### PR TITLE
Uncover buffer_position method in parser

### DIFF
--- a/xml/src/parser.rs
+++ b/xml/src/parser.rs
@@ -77,6 +77,10 @@ impl<R: BufRead> RdfXmlParser<R> {
             is_end: false,
         }
     }
+
+    pub fn buffer_position(&self) -> usize {
+        self.reader.reader.buffer_position()
+    }
 }
 
 impl<R: BufRead> TriplesParser for RdfXmlParser<R> {


### PR DESCRIPTION
This allows access to the underlying location of the quick-xml parser.

This is a pretty minimal change, but it provides what is needed. I did think of a richer change but it is not easy to incorporate into rio with the current state of quick-xml which does not report it's buffer position through it's errors. So I think it is dependent on this issue from quick-xml.

https://github.com/tafia/quick-xml/issues/313

Another way would be to port to https://github.com/netvl/xml-rs which reports line and column co-ords as a part of it's error messaging. Clearly, that would be a substantial port, however. But, it would be interesting to see what the differences are in performance between this and quick-xml in practice.