### PR TITLE
Adds nested entity resolution to RdfXmlParser.

### DIFF
--- a/testsuite/rio-tests/xml_nested_entities_definition.rdf
+++ b/testsuite/rio-tests/xml_nested_entities_definition.rdf
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE rdf:RDF [
+  <!ENTITY ex "http://example.com/">
+  <!ENTITY w3 "http://www.w3.org">
+  <!ENTITY rdf "&w3;/1999/02/22-rdf-syntax-ns#">
+  <!ENTITY rdfs "&w3;/2000/01/rdf-schema#">
+  <!ENTITY xsd "&w3;/2001/XMLSchema#">
+]>
+
+<rdf:RDF xmlns:ex2="&ex;2/" xmlns:rdf="&rdf;">
+	<rdf:Description rdf:about="&ex;foo">
+	    <ex2:test rdf:datatype="&xsd;string">bar</ex2:test>
+	</rdf:Description>
+</rdf:RDF>

--- a/xml/src/parser.rs
+++ b/xml/src/parser.rs
@@ -273,6 +273,11 @@ impl<R: BufRead> RdfXmlReader<R> {
                     "<!ENTITY declarations values should end with >",
                 ));
             }
+
+            // Resolves custom entities within the current entity definition.
+            let entity_value =
+                quick_xml::escape::unescape_with(entity_value, &self.custom_entities)
+                    .map_err(|e| quick_xml::Error::EscapeError(e))?;
             self.custom_entities
                 .insert(entity_name.to_vec(), entity_value.to_vec());
         }


### PR DESCRIPTION
Addresses #110 

I changed the definition of `parser::parse_doctype()` so that entity values are escaped before they are added to the set of custom entities.
I added a corresponding instance to `rio_testsuite`.
The following example would still cause failure, as `w3` is defined after e.g. `rdf`:

```xml
<?xml version="1.0"?>

<!DOCTYPE rdf:RDF [
  <!ENTITY ex "http://example.com/">
  <!ENTITY rdf "&w3;/1999/02/22-rdf-syntax-ns#">
  <!ENTITY rdfs "&w3;/2000/01/rdf-schema#">
  <!ENTITY xsd "&w3;/2001/XMLSchema#">
  <!ENTITY w3 "http://www.w3.org">
]>

<rdf:RDF xmlns:ex2="&ex;2/" xmlns:rdf="&rdf;">
	<rdf:Description rdf:about="&ex;foo">
	    <ex2:test rdf:datatype="&xsd;string">bar</ex2:test>
	</rdf:Description>
</rdf:RDF>
```