### PR TITLE
Turtle: Makes sure prefixes and keywords are properly disambiguated v2

### DIFF
--- a/testsuite/rio-tests/keyword_vs_prefix.nq
+++ b/testsuite/rio-tests/keyword_vs_prefix.nq
@@ -1,3 +1,6 @@
 <http://example.com/prefix/s> <http://example.com/prefix/p> <http://example.com/true/o> .
 <http://example.com/base/s> <http://example.com/base/p> <http://example.com/false/o> .
 <http://example.com/graph/s> <http://example.com/graph/p> <http://example.com/graph/o> <http://example.com/graph/g> .
+<http://example.com/prefixF/s> <http://example.com/prefixF/p> <http://example.com/trueF/o> .
+<http://example.com/baseF/s> <http://example.com/baseF/p> <http://example.com/falseF/o> .
+<http://example.com/graphF/s> <http://example.com/graphF/p> <http://example.com/graphF/o> <http://example.com/graphF/g> .

--- a/testsuite/rio-tests/keyword_vs_prefix.nt
+++ b/testsuite/rio-tests/keyword_vs_prefix.nt
@@ -1,2 +1,4 @@
 <http://example.com/prefix/s> <http://example.com/prefix/p> <http://example.com/true/o> .
 <http://example.com/base/s> <http://example.com/base/p> <http://example.com/false/o> .
+<http://example.com/prefixF/s> <http://example.com/prefixF/p> <http://example.com/trueF/o> .
+<http://example.com/baseF/s> <http://example.com/baseF/p> <http://example.com/falseF/o> .

--- a/testsuite/rio-tests/keyword_vs_prefix.trig
+++ b/testsuite/rio-tests/keyword_vs_prefix.trig
@@ -4,7 +4,15 @@ prefix base: <base/>
 prefix graph: <graph/>
 prefix true: <true/>
 prefix false: <false/>
+prefix prefixF: <prefixF/>
+prefix baseF: <baseF/>
+prefix graphF: <graphF/>
+prefix trueF: <trueF/>
+prefix falseF: <falseF/>
 
 prefix:s prefix:p true:o .
 base:s base:p false:o .
 graph:g { graph:s graph:p graph:o . }
+prefixF:s prefixF:p trueF:o .
+baseF:s baseF:p falseF:o .
+graphF:g { graphF:s graphF:p graphF:o . }

--- a/testsuite/rio-tests/keyword_vs_prefix.ttl
+++ b/testsuite/rio-tests/keyword_vs_prefix.ttl
@@ -3,6 +3,12 @@ prefix prefix: <prefix/>
 prefix base: <base/>
 prefix true: <true/>
 prefix false: <false/>
+prefix prefixF: <prefixF/>
+prefix baseF: <baseF/>
+prefix trueF: <trueF/>
+prefix falseF: <falseF/>
 
 prefix:s prefix:p true:o .
 base:s base:p false:o .
+prefixF:s prefixF:p trueF:o .
+baseF:s baseF:p falseF:o .


### PR DESCRIPTION
Handle properly "baseUrl:" and not only "base:"