### PR TITLE
Increases MSRV to 1.63

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update && rustup override set 1.60.0 && rustup component add clippy
+      - run: rustup update && rustup override set 1.63.0 && rustup component add clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings -D clippy::all
       - run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::all
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update && rustup override set 1.60.0
+      - run: rustup update && rustup override set 1.63.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --all-features --no-deps
         env:

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 Common data structures for RDF formats parsers and serializers
 """
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/turtle/Cargo.toml
+++ b/turtle/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 RDF Turtle, Trig, N-Triples and N-Quads parsers and serializers
 """
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/xml/Cargo.toml
+++ b/xml/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 RDF/XML parser and serializer
 """
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Required by `rayon-core v1.12.0`, which we depend on.
This should fix CI builds.