### PR TITLE
Removes redundant explicit link targets [minor]

### DIFF
--- a/api/src/formatter.rs
+++ b/api/src/formatter.rs
@@ -5,7 +5,7 @@
 use crate::model::{Quad, Triple};
 use std::error::Error;
 
-/// A formatter for [`Triple`](super::model::Triple).
+/// A formatter for [`Triple`].
 pub trait TriplesFormatter {
     type Error: Error;
 
@@ -13,7 +13,7 @@ pub trait TriplesFormatter {
     fn format(&mut self, triple: &Triple<'_>) -> Result<(), Self::Error>;
 }
 
-/// A formatter for [`Quad`](super::model::Quad).
+/// A formatter for [`Quad`].
 pub trait QuadsFormatter {
     type Error: Error;
 

--- a/api/src/parser.rs
+++ b/api/src/parser.rs
@@ -7,7 +7,7 @@ pub use crate::generalized::parser::*;
 use crate::model::{Quad, Triple};
 use std::error::Error;
 
-/// A parser returning [`Triple`](super::model::Triple).
+/// A parser returning [`Triple`].
 pub trait TriplesParser: Sized {
     type Error: Error;
 
@@ -40,7 +40,7 @@ pub trait TriplesParser: Sized {
 
     /// Converts the parser into a `Result<T, E>` iterator.
     ///
-    /// `convert_triple` is a function converting Rio [`Triple`](super::model::Triple) to `T`.
+    /// `convert_triple` is a function converting Rio [`Triple`] to `T`.
     fn into_iter<T, E: From<Self::Error>, F: FnMut(Triple<'_>) -> Result<T, E>>(
         self,
         convert_triple: F,
@@ -91,7 +91,7 @@ impl<T, E: From<P::Error>, F: FnMut(Triple<'_>) -> Result<T, E>, P: TriplesParse
     }
 }
 
-/// A parser returning [`Quad`](super::model::Quad).
+/// A parser returning [`Quad`].
 pub trait QuadsParser: Sized {
     type Error: Error;
 
@@ -124,7 +124,7 @@ pub trait QuadsParser: Sized {
 
     /// Converts the parser into a `Result<T, E>` iterator.
     ///
-    /// `convert_triple` is a function converting Rio [`Triple`](super::model::Triple) to `T`.
+    /// `convert_triple` is a function converting Rio [`Triple`] to `T`.
     fn into_iter<T, E: From<Self::Error>, F: FnMut(Quad<'_>) -> Result<T, E>>(
         self,
         convert_quad: F,


### PR DESCRIPTION
because label contains path that resolves to the same destination